### PR TITLE
Add support for customer stages

### DIFF
--- a/.github/actions/get-product-parameters/action.yml
+++ b/.github/actions/get-product-parameters/action.yml
@@ -3,10 +3,6 @@ description: get product parameters for building product
 author: datavisyn
 
 inputs:
-  dv_customers:
-    description: "customers of datavisyn; seperated with ','"
-    required: true
-    type: string
   branch_name:
     description: "name of the current branch"
     required: true
@@ -120,7 +116,6 @@ runs:
         echo "create_workspace=$create_workspace" >> "$GITHUB_OUTPUT"
         echo "stage=$stage" >> "$GITHUB_OUTPUT"
       env:
-        DV_CUSTOMERS: ${{ inputs.dv_customers }}
         BRANCH_NAME: ${{ inputs.branch_name }}
         TIME_ZONE: ${{ inputs.time_zone }}
       shell: bash

--- a/.github/workflows/build-product.yml
+++ b/.github/workflows/build-product.yml
@@ -7,8 +7,6 @@ on:
         required: false
       DV_BOT_USER:
         required: false
-      DV_CUSTOMERS:
-        required: true
       DV_AWS_ECR_ROLE:
         required: false
       DV_AWS_REGION:
@@ -86,7 +84,6 @@ jobs:
       - uses: ./tmp/github-workflows/.github/actions/get-product-parameters
         id: get-parameters
         with:
-          dv_customers: ${{ secrets.DV_CUSTOMERS }}
           branch_name: ${{ github.ref_name }}
           time_zone: ${{ env.TIME_ZONE }}
   build-single:
@@ -146,6 +143,26 @@ jobs:
       matrix:
         customer: ${{ fromJSON(needs.prepare-build.outputs.customers) }}
     steps:
+      - name: determine stage to be deployed to
+        id: get-parameters
+        run: |
+          # Try to split the customer from the format customer:stage
+          customer="$(echo "$CUSTOMER_FULL" | cut -d ":" -s -f 1)"
+          stage="$(echo "$CUSTOMER_FULL" | cut -d ":" -s -f 2)"
+          # If nothing is found, we assume we just got the customer
+          if [ -z "$customer" ]; then
+            customer="$CUSTOMER_FULL"
+          fi
+          # And will deploy to develop if no stage is defined
+          if [ -z "$stage" ]; then
+            echo "customer $CUSTOMER_FULL does not include stage, using develop instead"
+            stage="develop"
+          fi
+          echo "customer=$customer" >> "$GITHUB_OUTPUT"
+          echo "stage=$stage" >> "$GITHUB_OUTPUT"
+        env:
+          CUSTOMER_FULL: ${{ matrix.customer }}
+        shell: bash
       - name: trigger deployment
         uses: datavisyn/github-action-trigger-workflow@v1
         with:
@@ -155,5 +172,4 @@ jobs:
           workflow_file_name: "deploy-app.yml"
           ref: ${{ env.WORKFLOW_BRANCH }}
           github_user: ${{ secrets.DV_BOT_USER }}
-          # TODO: The deployment is always triggered to develop, do we want to make this configurable?
-          client_payload: '{ "app": "${{ needs.prepare-build.outputs.app }}", "customer": "${{ matrix.customer }}", "stage": "develop", "sub_app": "${{ needs.prepare-build.outputs.sub_app }}", "branch": "${{ needs.prepare-build.outputs.image_tag2 }}" }'
+          client_payload: '{ "app": "${{ needs.prepare-build.outputs.app }}", "customer": "${{ steps.get-parameters.outputs.customer }}", "stage": "${{ steps.get-parameters.outputs.stage }}", "sub_app": "${{ needs.prepare-build.outputs.sub_app }}", "branch": "${{ needs.prepare-build.outputs.image_tag2 }}" }'

--- a/.github/workflows/build-single-product-part.yml
+++ b/.github/workflows/build-single-product-part.yml
@@ -9,8 +9,6 @@ on:
         required: false
       DV_BOT_USER:
         required: false
-      DV_CUSTOMERS:
-        required: true
       DV_AWS_ECR_ROLE:
         required: false
       DV_AWS_REGION:

--- a/.github/workflows/build-workspace-product-part.yml
+++ b/.github/workflows/build-workspace-product-part.yml
@@ -9,8 +9,6 @@ on:
         required: false
       DV_BOT_USER:
         required: false
-      DV_CUSTOMERS:
-        required: true
       DV_AWS_ECR_ROLE:
         required: false
       DV_AWS_REGION:

--- a/.github/workflows/deploy-product.yml
+++ b/.github/workflows/deploy-product.yml
@@ -5,8 +5,6 @@ on:
     secrets:
       DATAVISYN_BOT_REPO_TOKEN:
         required: true
-      DV_CUSTOMERS:
-        required: true
       DV_DEVOPS:
         required: true
       DV_QMS:
@@ -75,7 +73,6 @@ jobs:
       - uses: ./tmp/github-workflows/.github/actions/get-product-parameters
         id: get-parameters
         with:
-          dv_customers: ${{ secrets.DV_CUSTOMERS }}
           branch_name: ${{ github.ref_name }}
           time_zone: ${{ env.TIME_ZONE }}
       - name: trigger deployment

--- a/.github/workflows/release-product.yml
+++ b/.github/workflows/release-product.yml
@@ -7,8 +7,6 @@ on:
         required: true
       DV_DEVOPS:
         required: true
-      DV_CUSTOMERS:
-        required: true
       DV_QMS:
         required: true
 
@@ -208,9 +206,9 @@ jobs:
           echo "release_version=$release_version"
           echo "main_branch_name=$main_branch_name"
           echo "develop_branch_name=$develop_branch_name"
-          echo "::set-output name=release_version::$release_version"
-          echo "::set-output name=main_branch_name::$main_branch_name"
-          echo "::set-output name=develop_branch_name::$develop_branch_name"
+          echo "release_version=$release_version >> $GITHUB_OUTPUT"
+          echo "main_branch_name=$main_branch_name >> $GITHUB_OUTPUT"
+          echo "develop_branch_name=$develop_branch_name >> $GITHUB_OUTPUT"
         env:
           BRANCH_NAME: ${{ github.ref_name }}
       - name: delete release branch


### PR DESCRIPTION
In your `visyn_product.json` you can define `customers` as `["datavisyn"]` or as `["datavisyn:develop"]`. If you don't specify a stage, it will default to develop.