### PR TITLE
Preparation for "Add nightly build jobs for all repositories"

### DIFF
--- a/.github/workflows/build-node-python.yml
+++ b/.github/workflows/build-node-python.yml
@@ -16,7 +16,7 @@ on:
         required: false
       PYTHON_VERSION:
         required: false
-        
+
 env: 
   NPM_REGISTRY: "https://registry.npmjs.org/"
   NODE_VERSION: "16.16"

--- a/.github/workflows/build-node-python.yml
+++ b/.github/workflows/build-node-python.yml
@@ -42,12 +42,13 @@ jobs:
       # checkout specific source repository
       - uses: actions/checkout@v3
         with:
+          ref: ${{ inputs.branch }}
           token: ${{ github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN  || github.token  }} # has to set because otherwise it will not work
       # checkout this workflow repository to get actions
       - uses: actions/checkout@v3
         with:
           repository: datavisyn/github-workflows
-          ref: ${{ inputs.branch }}
+          ref: main
           path: ./tmp/github-workflows
       - uses: ./tmp/github-workflows/.github/actions/build-node
         with:
@@ -60,11 +61,13 @@ jobs:
     steps: 
       # checkout specific source repository     
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.branch }}
       # checkout this workflow repository to get actions
       - uses: actions/checkout@v3
         with:
           repository: datavisyn/github-workflows
-          ref: ${{ inputs.branch }}
+          ref: main
           path: ./tmp/github-workflows
       - uses: ./tmp/github-workflows/.github/actions/build-python
         with:

--- a/.github/workflows/build-node-python.yml
+++ b/.github/workflows/build-node-python.yml
@@ -2,6 +2,13 @@ name: Build python and node repositories
 
 on: 
   workflow_call:
+    inputs:
+      branch:
+        description: "Branch name"
+        type: string
+        required: false
+        default: ${{ github.ref }}
+        
     secrets:
       DATAVISYN_BOT_REPO_TOKEN:
         required: false
@@ -9,7 +16,7 @@ on:
         required: false
       PYTHON_VERSION:
         required: false
-
+        
 env: 
   NPM_REGISTRY: "https://registry.npmjs.org/"
   NODE_VERSION: "16.16"
@@ -40,7 +47,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: datavisyn/github-workflows
-          ref: main
+          ref: ${{ inputs.branch }}
           path: ./tmp/github-workflows
       - uses: ./tmp/github-workflows/.github/actions/build-node
         with:
@@ -57,7 +64,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: datavisyn/github-workflows
-          ref: main
+          ref: ${{ inputs.branch }}
           path: ./tmp/github-workflows
       - uses: ./tmp/github-workflows/.github/actions/build-python
         with:

--- a/.github/workflows/build-node.yml
+++ b/.github/workflows/build-node.yml
@@ -2,6 +2,12 @@ name: Build node repositories
 
 on: 
   workflow_call:
+    inputs:
+      branch:
+        description: "Branch name"
+        type: string
+        required: false
+        default: ${{ github.ref }}
     secrets:
       DATAVISYN_BOT_REPO_TOKEN:
         required: false
@@ -34,7 +40,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: datavisyn/github-workflows
-          ref: main
+          ref: ${{ inputs.branch }}
           path: ./tmp/github-workflows
       - uses: ./tmp/github-workflows/.github/actions/build-node
         with:

--- a/.github/workflows/build-node.yml
+++ b/.github/workflows/build-node.yml
@@ -35,12 +35,13 @@ jobs:
       # checkout specific source repository    
       - uses: actions/checkout@v3
         with:
+          ref: ${{ inputs.branch }}
           token: ${{ github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN  || github.token }} # has to set because otherwise it will not work
       # checkout this workflow repository to get actions
       - uses: actions/checkout@v3
         with:
           repository: datavisyn/github-workflows
-          ref: ${{ inputs.branch }}
+          ref: main
           path: ./tmp/github-workflows
       - uses: ./tmp/github-workflows/.github/actions/build-node
         with:

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -2,6 +2,12 @@ name: Build python repositories
 
 on: 
   workflow_call:
+    inputs:
+      branch:
+        description: "Branch name"
+        type: string
+        required: false
+        default: ${{ github.ref }}
     secrets:
       DATAVISYN_BOT_REPO_TOKEN:
         required: false
@@ -31,7 +37,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: datavisyn/github-workflows
-          ref: main
+          ref: ${{ inputs.branch }}
           path: ./tmp/github-workflows
       - uses: ./tmp/github-workflows/.github/actions/build-python
         with:

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -33,11 +33,13 @@ jobs:
     steps:
       # checkout specific source repository  
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.branch }}
       # checkout this workflow repository to get actions
       - uses: actions/checkout@v3
         with:
           repository: datavisyn/github-workflows
-          ref: ${{ inputs.branch }}
+          ref: main
           path: ./tmp/github-workflows
       - uses: ./tmp/github-workflows/.github/actions/build-python
         with:


### PR DESCRIPTION
Updated our build-node-python.yml, build-python.yml, build-node.yml workflows to support passing of a branch (but keeping backwards compatibility by using the current one as fallback)

issue: https://github.com/datavisyn/github-maintenance/issues/55