### PR TITLE
Revert "added timeout to build product"

### DIFF
--- a/.github/workflows/build-product.yml
+++ b/.github/workflows/build-product.yml
@@ -2,11 +2,6 @@ name: build-product
 
 on:
   workflow_call:
-    inputs:
-      timeout:
-        description: "Timeout in minutes for each job"
-        type: string
-        default: 30
     secrets:
       DATAVISYN_BOT_REPO_TOKEN:
         required: false
@@ -63,7 +58,6 @@ jobs:
       create_workspace: ${{ steps.get-parameters.outputs.create_workspace }}
       stage: ${{ steps.get-parameters.outputs.stage }}
     runs-on: ubuntu-20.04
-    timeout-minutes: ${{ fromJSON(github.event.inputs.timeout) }}
     steps:
       # checkout specific repository
       - uses: actions/checkout@v3
@@ -106,7 +100,6 @@ jobs:
       image_tag2: ${{ needs.prepare-build.outputs.image_tag2 }}
       build_time: ${{ needs.prepare-build.outputs.build_time }}
       stage: ${{ needs.prepare-build.outputs.stage }}
-      timeout: ${{ inputs.timeout }}
     secrets: inherit
   build-workspace:
     needs: prepare-build
@@ -122,11 +115,9 @@ jobs:
       image_tag2: ${{ needs.prepare-build.outputs.image_tag2 }}
       build_time: ${{ needs.prepare-build.outputs.build_time }}
       stage: ${{ needs.prepare-build.outputs.stage }}
-      timeout: ${{ inputs.timeout }}
     secrets: inherit
   post-build:
     needs: [prepare-build, build-single, build-workspace]
-    timeout-minutes: ${{ fromJSON(github.event.inputs.timeout) }}
     if: ${{ always() && (needs.build-single.result == 'success' || needs.build-single.result == 'skipped') && (needs.build-workspace.result == 'success' || needs.build-workspace.result == 'skipped') && !(needs.build-workspace.result == 'skipped' && needs.build-single.result == 'skipped')}}
     runs-on: ubuntu-20.04
     steps:
@@ -148,7 +139,6 @@ jobs:
     # Add always() as otherwise the job is being skipped: https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions
     if: ${{ always() && needs.post-build.result == 'success' && fromJSON(needs.prepare-build.outputs.trigger_automatic_deployment) }}
     runs-on: ubuntu-20.04
-    timeout-minutes: ${{ fromJSON(github.event.inputs.timeout) }}
     strategy:
       matrix:
         customer: ${{ fromJSON(needs.prepare-build.outputs.customers) }}

--- a/.github/workflows/build-single-product-part.yml
+++ b/.github/workflows/build-single-product-part.yml
@@ -44,10 +44,6 @@ on:
           description: "stage for the image (develop or production) depending on the branch name"
           required: true
           type: string
-        timeout:
-          description: "Timeout in minutes for each job"
-          type: string
-          default: 30
 env:
   TIME_ZONE: "Europe/Vienna"
   NODE_VERSION: "16.16"
@@ -64,7 +60,6 @@ permissions:
 jobs:
   build-components:
     runs-on: ubuntu-20.04
-    timeout-minutes: ${{ fromJSON(github.event.inputs.timeout) }}
     steps:
       # checkout specific repository
       - uses: actions/checkout@v3

--- a/.github/workflows/build-workspace-product-part.yml
+++ b/.github/workflows/build-workspace-product-part.yml
@@ -44,10 +44,6 @@ on:
           description: "stage for the image (develop or production) depending on the branch name"
           required: true
           type: string
-        timeout:
-          description: "Timeout in minutes for each job"
-          type: string
-          default: 30
 env:
   VISYN_SCRIPTS_VERSION: "develop"
   TIME_ZONE: "Europe/Vienna"
@@ -65,7 +61,6 @@ permissions:
 jobs:
   build-components:
     runs-on: ubuntu-20.04
-    timeout-minutes: ${{ fromJSON(github.event.inputs.timeout) }}
     steps:
       # checkout specific repository
       - uses: actions/checkout@v3
@@ -196,20 +191,20 @@ jobs:
           product_version=$(jq -rc '.version' ./package.json)
           echo "product_version=$product_version"
           
-          if [[ "$product_version" == *"SNAPSHOT"* ]]; then
+          if [[ $product_version == *"SNAPSHOT"* ]]; then
             echo "replace SNAPSHOT in version with timestamp"
-            product_version=${product_version/SNAPSHOT/$(date +%Y%m%d-%H%M%S)}
+            product_version=$(echo "$product_version" | sed "s/SNAPSHOT/$(date +%Y%m%d-%H%M%S)/g")
             echo "product_version=$product_version"
           fi
 
-          workspace_version=$(jq -rc '.version' ./tmp/"$COMPONENT"/package.json)
+          workspace_version=$(jq -rc '.version' ./tmp/$COMPONENT/package.json)
           echo "workspace_version=$workspace_version"
 
-          if [[ "$product_version" != "$workspace_version" ]]; then
+          if [[ $product_version != $workspace_version ]]; then
             echo "update workspace version"
-            jq --arg version "$product_version" '.version = $version' ./tmp/"$COMPONENT"/package.json > ./tmp/"$COMPONENT"/package.json.tmp
-            mv ./tmp/"$COMPONENT"/package.json.tmp ./tmp/"$COMPONENT"/package.json
-            echo "workspace version updated to $(jq -rc '.version' ./tmp/"$COMPONENT"/package.json)"
+            jq --arg version "$product_version" '.version = $version' ./tmp/$COMPONENT/package.json > ./tmp/$COMPONENT/package.json.tmp
+            mv ./tmp/$COMPONENT/package.json.tmp ./tmp/$COMPONENT/package.json
+            echo "workspace version updated to $(jq -rc '.version' ./tmp/$COMPONENT/package.json)"
           fi
         env:
           COMPONENT: ${{ inputs.component }}


### PR DESCRIPTION
Reverts datavisyn/github-workflows#22

Because it resulted in errors like https://github.com/datavisyn/bioinsight_product/actions/runs/5785979305

```
Error when evaluating 'timeout-minutes' for job 'prepare-build'. datavisyn/github-workflows/.github/workflows/build-product.yml@new_deployment (Line: 66, Col: 22): Error parsing fromJson,datavisyn/github-workflows/.github/workflows/build-product.yml@new_deployment (Line: 66, Col: 22): Error reading JToken from JsonReader. Path '', line 0, position 0.,datavisyn/github-workflows/.github/workflows/build-product.yml@new_deployment (Line: 66, Col: 22): Unexpected value ''
```