### PR TITLE
feat: add CHECKOUT_TOKEN support for build-product.yml

### DIFF
--- a/.github/workflows/build-product.yml
+++ b/.github/workflows/build-product.yml
@@ -15,9 +15,7 @@ on:
         required: false
       GITLAB_HOST:
         required: false
-    inputs:
-      token:
-        type: string
+      TOKEN:
         required: false
         description: Token to pass to the build-single and build-workspace jobs. Use this to allow the checkout actions to access private repositories.
 
@@ -99,7 +97,6 @@ jobs:
       image_tag2: ${{ needs.prepare-build.outputs.image_tag2 }}
       build_time: ${{ needs.prepare-build.outputs.build_time }}
       stage: ${{ needs.prepare-build.outputs.stage }}
-      token: ${{ inputs.token }}
     secrets: inherit
   build-workspace:
     needs: prepare-build

--- a/.github/workflows/build-product.yml
+++ b/.github/workflows/build-product.yml
@@ -90,7 +90,7 @@ jobs:
       fail-fast: true
       matrix:
         component: ${{fromJson(needs.prepare-build.outputs.components)}}
-    uses: datavisyn/github-workflows/.github/workflows/build-single-product-part.yml@new_deployment-product_token
+    uses: datavisyn/github-workflows/.github/workflows/build-single-product-part.yml@new_deployment
     with:
       component: ${{ matrix.component }}
       image_tag1: ${{ needs.prepare-build.outputs.image_tag1 }}

--- a/.github/workflows/build-product.yml
+++ b/.github/workflows/build-product.yml
@@ -15,6 +15,11 @@ on:
         required: false
       GITLAB_HOST:
         required: false
+    inputs:
+      token:
+        type: string
+        required: false
+        description: Token to pass to the build-single and build-workspace jobs. Use this to allow the checkout actions to access private repositories.
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref || github.head_ref }}"
@@ -87,13 +92,14 @@ jobs:
       fail-fast: true
       matrix:
         component: ${{fromJson(needs.prepare-build.outputs.components)}}
-    uses: datavisyn/github-workflows/.github/workflows/build-single-product-part.yml@new_deployment
+    uses: datavisyn/github-workflows/.github/workflows/build-single-product-part.yml@new_deployment-product_token
     with:
       component: ${{ matrix.component }}
       image_tag1: ${{ needs.prepare-build.outputs.image_tag1 }}
       image_tag2: ${{ needs.prepare-build.outputs.image_tag2 }}
       build_time: ${{ needs.prepare-build.outputs.build_time }}
       stage: ${{ needs.prepare-build.outputs.stage }}
+      token: ${{ inputs.token }}
     secrets: inherit
   build-workspace:
     needs: prepare-build

--- a/.github/workflows/build-product.yml
+++ b/.github/workflows/build-product.yml
@@ -15,7 +15,7 @@ on:
         required: false
       GITLAB_HOST:
         required: false
-      TOKEN:
+      CHECKOUT_TOKEN:
         required: false
         description: Token to pass to the build-single and build-workspace jobs. Use this to allow the checkout actions to access private repositories.
 

--- a/.github/workflows/build-product.yml
+++ b/.github/workflows/build-product.yml
@@ -17,7 +17,7 @@ on:
         required: false
       CHECKOUT_TOKEN:
         required: false
-        description: Token to pass to the build-single and build-workspace jobs. Use this to allow the checkout actions to access private repositories.
+        description: Token to pass to the build-single job. Use this to allow the checkout actions to access private repositories.
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref || github.head_ref }}"

--- a/.github/workflows/build-single-product-part.yml
+++ b/.github/workflows/build-single-product-part.yml
@@ -17,6 +17,9 @@ on:
         required: false
       GITLAB_HOST:
         required: false
+      TOKEN:
+        required: false
+        description: "token to use for the checkout actions to access private repositories"
     inputs:
         component:
           description: "component that should be built"
@@ -38,10 +41,6 @@ on:
           description: "stage for the image (develop or production) depending on the branch name"
           required: true
           type: string
-        token:
-          description: "token to use for the checkout actions to access private repositories"
-          required: false
-          type: string
 env:
   TIME_ZONE: "Europe/Vienna"
   NODE_VERSION: "20.9"
@@ -62,7 +61,7 @@ jobs:
       # checkout specific repository
       - uses: actions/checkout@v3
         with:
-          token: ${{ inputs.token || github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN || github.token }}
+          token: ${{ secrets.TOKEN || github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN || github.token }}
       # checkout this workflow repository to get actions
       - uses: actions/checkout@v3
         with:
@@ -125,7 +124,7 @@ jobs:
             git config --global url."git+https://$GITLAB_TOKEN@$GITLAB_HOST/".insteadOf "git+ssh://git@$GITLAB_HOST:"
           fi
         env:
-          _GITHUB_TOKEN: ${{ inputs.token || github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN || github.token }}
+          _GITHUB_TOKEN: ${{ secrets.TOKEN || github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN || github.token }}
           GITLAB_TOKEN:  ${{ secrets.GITLAB_TOKEN }}
           GITLAB_HOST:  ${{ secrets.GITLAB_HOST }}
       - name: Git clone app
@@ -145,7 +144,7 @@ jobs:
           REPO: ${{ steps.get-parameters.outputs.repo }}
           BRANCH: ${{ steps.get-parameters.outputs.branch }}
           APP: ${{ steps.get-parameters.outputs.app }}
-          GH_TOKEN: ${{ inputs.token || github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN || github.token }}
+          GH_TOKEN: ${{ secrets.TOKEN || github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN || github.token }}
           GITLAB_TOKEN:  ${{ secrets.GITLAB_TOKEN }}
           GITLAB_HOST:  ${{ secrets.GITLAB_HOST }}
       - name: Copy docker sources

--- a/.github/workflows/build-single-product-part.yml
+++ b/.github/workflows/build-single-product-part.yml
@@ -17,7 +17,7 @@ on:
         required: false
       GITLAB_HOST:
         required: false
-      TOKEN:
+      CHECKOUT_TOKEN:
         required: false
         description: "token to use for the checkout actions to access private repositories"
     inputs:
@@ -61,7 +61,7 @@ jobs:
       # checkout specific repository
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.TOKEN || github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN || github.token }}
+          token: ${{ secrets.CHECKOUT_TOKEN || github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN || github.token }}
       # checkout this workflow repository to get actions
       - uses: actions/checkout@v3
         with:
@@ -124,7 +124,7 @@ jobs:
             git config --global url."git+https://$GITLAB_TOKEN@$GITLAB_HOST/".insteadOf "git+ssh://git@$GITLAB_HOST:"
           fi
         env:
-          _GITHUB_TOKEN: ${{ secrets.TOKEN || github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN || github.token }}
+          _GITHUB_TOKEN: ${{ secrets.CHECKOUT_TOKEN || github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN || github.token }}
           GITLAB_TOKEN:  ${{ secrets.GITLAB_TOKEN }}
           GITLAB_HOST:  ${{ secrets.GITLAB_HOST }}
       - name: Git clone app
@@ -144,7 +144,7 @@ jobs:
           REPO: ${{ steps.get-parameters.outputs.repo }}
           BRANCH: ${{ steps.get-parameters.outputs.branch }}
           APP: ${{ steps.get-parameters.outputs.app }}
-          GH_TOKEN: ${{ secrets.TOKEN || github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN || github.token }}
+          GH_TOKEN: ${{ secrets.CHECKOUT_TOKEN || github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN || github.token }}
           GITLAB_TOKEN:  ${{ secrets.GITLAB_TOKEN }}
           GITLAB_HOST:  ${{ secrets.GITLAB_HOST }}
       - name: Copy docker sources

--- a/.github/workflows/build-single-product-part.yml
+++ b/.github/workflows/build-single-product-part.yml
@@ -38,6 +38,10 @@ on:
           description: "stage for the image (develop or production) depending on the branch name"
           required: true
           type: string
+        token:
+          description: "token to use for the checkout actions to access private repositories"
+          required: false
+          type: string
 env:
   TIME_ZONE: "Europe/Vienna"
   NODE_VERSION: "20.9"
@@ -58,7 +62,7 @@ jobs:
       # checkout specific repository
       - uses: actions/checkout@v3
         with:
-          token: ${{ github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN || github.token }}
+          token: ${{ inputs.token || github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN || github.token }}
       # checkout this workflow repository to get actions
       - uses: actions/checkout@v3
         with:
@@ -121,7 +125,7 @@ jobs:
             git config --global url."git+https://$GITLAB_TOKEN@$GITLAB_HOST/".insteadOf "git+ssh://git@$GITLAB_HOST:"
           fi
         env:
-          _GITHUB_TOKEN: ${{ github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN || github.token }}
+          _GITHUB_TOKEN: ${{ inputs.token || github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN || github.token }}
           GITLAB_TOKEN:  ${{ secrets.GITLAB_TOKEN }}
           GITLAB_HOST:  ${{ secrets.GITLAB_HOST }}
       - name: Git clone app
@@ -141,7 +145,7 @@ jobs:
           REPO: ${{ steps.get-parameters.outputs.repo }}
           BRANCH: ${{ steps.get-parameters.outputs.branch }}
           APP: ${{ steps.get-parameters.outputs.app }}
-          GH_TOKEN: ${{ github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN || github.token }}
+          GH_TOKEN: ${{ inputs.token || github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN || github.token }}
           GITLAB_TOKEN:  ${{ secrets.GITLAB_TOKEN }}
           GITLAB_HOST:  ${{ secrets.GITLAB_HOST }}
       - name: Copy docker sources


### PR DESCRIPTION
In case the repo to checkout (i.e. the one in visyn_product.json) is not accessible for the datavisyn bot, we can now pass it explicitly as CHECKOUT_TOKEN secret. 