### PR TITLE
feat: Allow building Dockerfiles from app in standalone mode

### DIFF
--- a/.github/workflows/build-product.yml
+++ b/.github/workflows/build-product.yml
@@ -27,7 +27,7 @@ env:
   TIME_ZONE: "Europe/Vienna"
   NODE_VERSION: "20.9"
   PYTHON_VERSION: "3.10"
-  WORKFLOW_BRANCH: "new_deployment"
+  WORKFLOW_BRANCH: "dockerfile_in_app"
   PYTHON_BASE_IMAGE: "python:3.10.8-slim-bullseye"
   DATAVISYN_PYTHON_BASE_IMAGE: "188237246440.dkr.ecr.eu-central-1.amazonaws.com/datavisyn/base/python:main"
   DATAVISYN_NGINX_BASE_IMAGE: "188237246440.dkr.ecr.eu-central-1.amazonaws.com/datavisyn/base/nginx:main"
@@ -90,7 +90,7 @@ jobs:
       fail-fast: true
       matrix:
         component: ${{fromJson(needs.prepare-build.outputs.components)}}
-    uses: datavisyn/github-workflows/.github/workflows/build-single-product-part.yml@new_deployment
+    uses: datavisyn/github-workflows/.github/workflows/build-single-product-part.yml@dockerfile_in_app
     with:
       component: ${{ matrix.component }}
       image_tag1: ${{ needs.prepare-build.outputs.image_tag1 }}

--- a/.github/workflows/build-product.yml
+++ b/.github/workflows/build-product.yml
@@ -27,7 +27,7 @@ env:
   TIME_ZONE: "Europe/Vienna"
   NODE_VERSION: "20.9"
   PYTHON_VERSION: "3.10"
-  WORKFLOW_BRANCH: "dockerfile_in_app"
+  WORKFLOW_BRANCH: "new_deployment"
   PYTHON_BASE_IMAGE: "python:3.10.8-slim-bullseye"
   DATAVISYN_PYTHON_BASE_IMAGE: "188237246440.dkr.ecr.eu-central-1.amazonaws.com/datavisyn/base/python:main"
   DATAVISYN_NGINX_BASE_IMAGE: "188237246440.dkr.ecr.eu-central-1.amazonaws.com/datavisyn/base/nginx:main"
@@ -90,7 +90,7 @@ jobs:
       fail-fast: true
       matrix:
         component: ${{fromJson(needs.prepare-build.outputs.components)}}
-    uses: datavisyn/github-workflows/.github/workflows/build-single-product-part.yml@dockerfile_in_app
+    uses: datavisyn/github-workflows/.github/workflows/build-single-product-part.yml@new_deployment
     with:
       component: ${{ matrix.component }}
       image_tag1: ${{ needs.prepare-build.outputs.image_tag1 }}

--- a/.github/workflows/build-single-product-part.yml
+++ b/.github/workflows/build-single-product-part.yml
@@ -263,6 +263,7 @@ jobs:
           ecr_repository: ${{ steps.get-parameters.outputs.ecr_repo }}
           image_tag: ${{ inputs.image_tag1 }}
       - name: check scan results
+        if: ${{ steps.get-parameters.outputs.skip_image_check != 'true' }}
         run: |
           if [ "${{ steps.get-ecr-scan-result.outputs.critical }}" != "null" ] || [ "${{ steps.get-ecr-scan-result.outputs.high }}" != "null" ]; then
             echo "Docker image contains vulnerabilities at critical or high level"

--- a/.github/workflows/build-single-product-part.yml
+++ b/.github/workflows/build-single-product-part.yml
@@ -74,6 +74,7 @@ jobs:
           type=$(jq --arg var "${COMPONENT}" -rc '.components | to_entries | .[] | select(.key==$var)| .value.type' ./visyn_product.json)
           directory=$(jq --arg var "${COMPONENT}" -rc '.components | to_entries | .[] | select(.key==$var)| .value.directory' ./visyn_product.json)
           ecr_repo=$(jq --arg var "${COMPONENT}" -rc '.components | to_entries | .[] | select(.key==$var)| .value.ecr_repo' ./visyn_product.json)
+          dockerfile_in_app=$(jq --arg var "${COMPONENT}" -rc '.components | to_entries | .[] | select(.key==$var)| .value.dockerfile_in_app' ./visyn_product.json)
           app=$(jq  -rc '.app' ./visyn_product.json)
           repo=$(jq  -rc '.repo' ./visyn_product.json)
           branch=$(jq  -rc '.branch' ./visyn_product.json)
@@ -87,6 +88,7 @@ jobs:
           echo "type=$type"
           echo "directory=$directory"
           echo "ecr_repo=$ecr_repo"
+          echo "dockerfile_in_app=$dockerfile_in_app"
           echo "app=$app"
           echo "repo=$repo"
           echo "branch=$branch"
@@ -97,6 +99,7 @@ jobs:
           echo "type=$type" >> "$GITHUB_OUTPUT"
           echo "directory=$directory" >> "$GITHUB_OUTPUT"
           echo "ecr_repo=$ecr_repo" >> "$GITHUB_OUTPUT"
+          echo "dockerfile_in_app=$dockerfile_in_app" >> "$GITHUB_OUTPUT"
           echo "app=$app" >> "$GITHUB_OUTPUT"
           echo "repo=$repo" >> "$GITHUB_OUTPUT"
           echo "branch=$branch" >> "$GITHUB_OUTPUT"
@@ -224,7 +227,7 @@ jobs:
           aws_region: ${{ vars.DV_AWS_REGION }}
           ecr_registry: ${{ vars.DV_AWS_ECR_REGISTRY }}
           ecr_repository: ${{ steps.get-parameters.outputs.ecr_repo }}
-          docker_file: ./tmp/${{ inputs.component }}/${{ steps.get-parameters.outputs.app }}/docker/Dockerfile
+          docker_file: ./tmp/${{ inputs.component }}/${{ steps.get-parameters.outputs.app }}/${{ steps.get-parameters.outputs.dockerfile_in_app || 'docker/Dockerfile' }}
           current_directory: ./tmp/${{ inputs.component }}/${{ steps.get-parameters.outputs.app }}
           image_tag: ${{ inputs.image_tag1 }}
           build_args: |

--- a/.github/workflows/build-single-product-part.yml
+++ b/.github/workflows/build-single-product-part.yml
@@ -75,6 +75,9 @@ jobs:
           directory=$(jq --arg var "${COMPONENT}" -rc '.components | to_entries | .[] | select(.key==$var)| .value.directory' ./visyn_product.json)
           ecr_repo=$(jq --arg var "${COMPONENT}" -rc '.components | to_entries | .[] | select(.key==$var)| .value.ecr_repo' ./visyn_product.json)
           dockerfile_in_app=$(jq --arg var "${COMPONENT}" -rc '.components | to_entries | .[] | select(.key==$var)| .value.dockerfile_in_app' ./visyn_product.json)
+          if [ "$dockerfile_in_app" == "null" ]; then
+            dockerfile_in_app=docker/Dockerfile
+          fi
           app=$(jq  -rc '.app' ./visyn_product.json)
           repo=$(jq  -rc '.repo' ./visyn_product.json)
           branch=$(jq  -rc '.branch' ./visyn_product.json)
@@ -227,7 +230,7 @@ jobs:
           aws_region: ${{ vars.DV_AWS_REGION }}
           ecr_registry: ${{ vars.DV_AWS_ECR_REGISTRY }}
           ecr_repository: ${{ steps.get-parameters.outputs.ecr_repo }}
-          docker_file: ./tmp/${{ inputs.component }}/${{ steps.get-parameters.outputs.app }}/${{ steps.get-parameters.outputs.dockerfile_in_app || 'docker/Dockerfile' }}
+          docker_file: ./tmp/${{ inputs.component }}/${{ steps.get-parameters.outputs.app }}/${{ steps.get-parameters.outputs.dockerfile_in_app }}
           current_directory: ./tmp/${{ inputs.component }}/${{ steps.get-parameters.outputs.app }}
           image_tag: ${{ inputs.image_tag1 }}
           build_args: |

--- a/.github/workflows/build-single-product-part.yml
+++ b/.github/workflows/build-single-product-part.yml
@@ -74,6 +74,7 @@ jobs:
           type=$(jq --arg var "${COMPONENT}" -rc '.components | to_entries | .[] | select(.key==$var)| .value.type' ./visyn_product.json)
           directory=$(jq --arg var "${COMPONENT}" -rc '.components | to_entries | .[] | select(.key==$var)| .value.directory' ./visyn_product.json)
           ecr_repo=$(jq --arg var "${COMPONENT}" -rc '.components | to_entries | .[] | select(.key==$var)| .value.ecr_repo' ./visyn_product.json)
+          skip_image_check=$(jq --arg var "${COMPONENT}" -rc '.components | to_entries | .[] | select(.key==$var)| .value.skip_image_check' ./visyn_product.json)
           dockerfile_in_app=$(jq --arg var "${COMPONENT}" -rc '.components | to_entries | .[] | select(.key==$var)| .value.dockerfile_in_app' ./visyn_product.json)
           if [ "$dockerfile_in_app" == "null" ]; then
             dockerfile_in_app=docker/Dockerfile
@@ -92,6 +93,7 @@ jobs:
           echo "directory=$directory"
           echo "ecr_repo=$ecr_repo"
           echo "dockerfile_in_app=$dockerfile_in_app"
+          echo "skip_image_check=$skip_image_check"
           echo "app=$app"
           echo "repo=$repo"
           echo "branch=$branch"
@@ -103,6 +105,7 @@ jobs:
           echo "directory=$directory" >> "$GITHUB_OUTPUT"
           echo "ecr_repo=$ecr_repo" >> "$GITHUB_OUTPUT"
           echo "dockerfile_in_app=$dockerfile_in_app" >> "$GITHUB_OUTPUT"
+          echo "skip_image_check=$skip_image_check" >> "$GITHUB_OUTPUT"
           echo "app=$app" >> "$GITHUB_OUTPUT"
           echo "repo=$repo" >> "$GITHUB_OUTPUT"
           echo "branch=$branch" >> "$GITHUB_OUTPUT"
@@ -250,6 +253,7 @@ jobs:
             org.opencontainers.image.created=${{ inputs.build_time }}
             org.opencontainers.image.revision=${{ github.sha }}
       - name: scan image
+        if: ${{ steps.get-parameters.outputs.skip_image_check != 'true' }}
         id: get-ecr-scan-result
         uses: ./tmp/github-workflows/.github/actions/get-ecr-scan-result
         with:


### PR DESCRIPTION
Adds two flags to `visyn_product.json` components: 

* `dockerfile_in_app`: Path to the Dockerfile to be used for building this image (default: docker/Dockerfile)
* `skip_image_check`: Always skips the image check for this component


This allows to build arbitrary Dockerfiles as part of the product build.