### PR TITLE
fix: use visyn_scripts@v7 for workspace builds

### DIFF
--- a/.github/workflows/build-product.yml
+++ b/.github/workflows/build-product.yml
@@ -31,7 +31,6 @@ env:
   PYTHON_BASE_IMAGE: "python:3.10.8-slim-bullseye"
   DATAVISYN_PYTHON_BASE_IMAGE: "188237246440.dkr.ecr.eu-central-1.amazonaws.com/datavisyn/base/python:main"
   DATAVISYN_NGINX_BASE_IMAGE: "188237246440.dkr.ecr.eu-central-1.amazonaws.com/datavisyn/base/nginx:main"
-  VISYN_SCRIPTS_VERSION: "develop"
 
 permissions:
   id-token: write

--- a/.github/workflows/build-product.yml
+++ b/.github/workflows/build-product.yml
@@ -31,6 +31,7 @@ env:
   PYTHON_BASE_IMAGE: "python:3.10.8-slim-bullseye"
   DATAVISYN_PYTHON_BASE_IMAGE: "188237246440.dkr.ecr.eu-central-1.amazonaws.com/datavisyn/base/python:main"
   DATAVISYN_NGINX_BASE_IMAGE: "188237246440.dkr.ecr.eu-central-1.amazonaws.com/datavisyn/base/nginx:main"
+  VISYN_SCRIPTS_VERSION: "develop"
 
 permissions:
   id-token: write

--- a/.github/workflows/build-product.yml
+++ b/.github/workflows/build-product.yml
@@ -106,7 +106,7 @@ jobs:
       fail-fast: true
       matrix:
         component: ${{fromJson(needs.prepare-build.outputs.components)}}
-    uses: datavisyn/github-workflows/.github/workflows/build-workspace-product-part.yml@new_deployment
+    uses: datavisyn/github-workflows/.github/workflows/build-workspace-product-part.yml@thinkh/env-visyn_scripts-version
     with:
       component: ${{ matrix.component }}
       image_tag1: ${{ needs.prepare-build.outputs.image_tag1 }}

--- a/.github/workflows/build-workspace-product-part.yml
+++ b/.github/workflows/build-workspace-product-part.yml
@@ -39,7 +39,7 @@ on:
           required: true
           type: string
 env:
-  VISYN_SCRIPTS_VERSION: "develop"
+  VISYN_SCRIPTS_VERSION: "v7" # visyn_scripts@v7 is the last version with workspace support
   TIME_ZONE: "Europe/Vienna"
   NODE_VERSION: "20.9"
   PYTHON_VERSION: "3.10"


### PR DESCRIPTION
use visyn_scripts@v7 as default for workspace builds. v7 is the last version with workspace support.