### PR TITLE
feat: make visyn_scripts@v7 the default version

### DIFF
--- a/.github/workflows/build-workspace-product-part.yml
+++ b/.github/workflows/build-workspace-product-part.yml
@@ -39,7 +39,7 @@ on:
           required: true
           type: string
 env:
-  VISYN_SCRIPTS_VERSION: "develop"
+  VISYN_SCRIPTS_VERSION: "v7" # visyn_scripts@v7 is the last version with workspace support
   TIME_ZONE: "Europe/Vienna"
   NODE_VERSION: "20.9"
   PYTHON_VERSION: "3.10"


### PR DESCRIPTION
use visyn_scripts@v7 as default for workspace builds. v7 is the last version with workspace support.