### PR TITLE
feat: add `spec` parameter to Cypress run options

### DIFF
--- a/.github/workflows/build-node-python.yml
+++ b/.github/workflows/build-node-python.yml
@@ -24,6 +24,11 @@ on:
         type: string
         required: false
         default: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || !!startsWith(github.ref, 'refs/heads/release-') || !!startsWith(github.ref, 'refs/heads/dependabot')}}
+      cypress_spec_param:
+        description: "Value for the `--spec` parameter. Example: `cypress/e2e/your_spec.cy.ts`. Will only work if cypress_enable: true."
+        type: string
+        required: false
+        default: ''
       playwright_enable:
         description: "Global enable for playwright"
         type: boolean
@@ -212,6 +217,7 @@ jobs:
             make start
           wait-on: "http://localhost:8080, http://localhost:9000/health"
           env: ${{ secrets.CYPRESS_ENV }}
+          spec: ${{ inputs.cypress_spec_param }}
       # rspack currently does not support Cypress component tests
       # - name: Run cypress component tests
       #   uses: cypress-io/github-action@v6


### PR DESCRIPTION
Add the option to specify spec files via inputs.

The default is an empty string which should be filtered out and work according to the github-action code: https://github.com/cypress-io/github-action/blob/48f6c1345cbaffc8bbc63193ce3e38294403c98c/index.js#L338-L346

### Further resources

* https://github.com/cypress-io/github-action?tab=readme-ov-file#specs
* https://docs.cypress.io/guides/guides/command-line#cypress-run-spec-lt-spec-gt