### PR TITLE
feat: install uv next to pip

### DIFF
--- a/.github/actions/build-node-python/action.yml
+++ b/.github/actions/build-node-python/action.yml
@@ -69,7 +69,7 @@ inputs:
     default: "3.10"
     required: true
   enable_python_cache:
-    description: "deprecated and disabled"
+    description: "deprecated and disabled as uv is usually faster anyways"
     required: false
     default: false
   run_python_lint:

--- a/.github/actions/build-node-python/action.yml
+++ b/.github/actions/build-node-python/action.yml
@@ -109,7 +109,8 @@ runs:
     - name: Install additional python requirements
       if: inputs.enable_python == 'true'
       run: |
-        python -m pip install --upgrade pip uv setuptools wheel
+        python -m pip install --upgrade pip uv
+        uv pip install setuptools wheel --system
         python --version
         pip --version
         uv --version

--- a/.github/actions/build-node-python/action.yml
+++ b/.github/actions/build-node-python/action.yml
@@ -69,9 +69,9 @@ inputs:
     default: "3.10"
     required: true
   enable_python_cache:
-    description: "enables the pip cache download and upload"
+    description: "deprecated and disabled"
     required: false
-    default: true
+    default: false
   run_python_lint:
     default: true
     required: false
@@ -105,13 +105,14 @@ runs:
       if: inputs.enable_python == 'true'
       with:
         python-version: ${{ inputs.python_version }}
-        cache: ${{ inputs.enable_python_cache == 'true' && 'pip' || null }}
+        # cache: ${{ inputs.enable_python_cache == 'true' && 'pip' || null }} Disable cache as uv is probably faster anyways: https://github.com/actions/setup-python/issues/822
     - name: Install additional python requirements
       if: inputs.enable_python == 'true'
       run: |
-        pip install setuptools wheel
+        python -m pip install --upgrade pip uv
         python --version
         pip --version
+        uv --version
       shell: bash
     # General
     - name: Git config

--- a/.github/actions/build-node-python/action.yml
+++ b/.github/actions/build-node-python/action.yml
@@ -109,7 +109,7 @@ runs:
     - name: Install additional python requirements
       if: inputs.enable_python == 'true'
       run: |
-        python -m pip install --upgrade pip uv
+        python -m pip install --upgrade pip uv setuptools wheel
         python --version
         pip --version
         uv --version

--- a/.github/workflows/build-node-python.yml
+++ b/.github/workflows/build-node-python.yml
@@ -102,7 +102,7 @@ env:
   PYPI_REGISTRY: "https://upload.pypi.org/legacy/"
   PYPI_USERNAME: "datavisyn"
   PYTHON_VERSION: "3.10"
-  WORKFLOW_BRANCH: "uv"
+  WORKFLOW_BRANCH: "main"
   POSTGRES_HOSTNAME: postgres_${{ github.job }}_${{ inputs.deduplication_id }}_${{ github.run_id }}_${{ github.run_attempt }}
 
 permissions:

--- a/.github/workflows/build-node-python.yml
+++ b/.github/workflows/build-node-python.yml
@@ -102,7 +102,7 @@ env:
   PYPI_REGISTRY: "https://upload.pypi.org/legacy/"
   PYPI_USERNAME: "datavisyn"
   PYTHON_VERSION: "3.10"
-  WORKFLOW_BRANCH: "main"
+  WORKFLOW_BRANCH: "uv"
   POSTGRES_HOSTNAME: postgres_${{ github.job }}_${{ inputs.deduplication_id }}_${{ github.run_id }}_${{ github.run_attempt }}
 
 permissions:

--- a/.github/workflows/build-single-product-part.yml
+++ b/.github/workflows/build-single-product-part.yml
@@ -218,8 +218,7 @@ jobs:
         run: |
           cd "./tmp/$COMPONENT/$APP"
           ls -lah
-          python -m pip install --upgrade pip uv
-          uv pip install setuptools wheel
+          python -m pip install --upgrade pip uv setuptools wheel
           make install
           make build
         env:

--- a/.github/workflows/build-single-product-part.yml
+++ b/.github/workflows/build-single-product-part.yml
@@ -218,7 +218,8 @@ jobs:
         run: |
           cd "./tmp/$COMPONENT/$APP"
           ls -lah
-          python -m pip install --upgrade pip uv setuptools wheel
+          python -m pip install --upgrade pip uv
+          uv pip install setuptools wheel --system
           make install
           make build
         env:

--- a/.github/workflows/build-single-product-part.yml
+++ b/.github/workflows/build-single-product-part.yml
@@ -212,14 +212,14 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ secrets.PYTHON_VERSION || env.PYTHON_VERSION }}
-          cache: 'pip'
+          # cache: 'pip' Disable cache as uv is probably faster anyways: https://github.com/actions/setup-python/issues/822
       - name: Build api
         if: ${{ steps.get-parameters.outputs.type == 'api' }}
         run: |
           cd "./tmp/$COMPONENT/$APP"
           ls -lah
-          python -m pip install --upgrade pip
-          pip install setuptools wheel
+          python -m pip install --upgrade pip uv
+          uv pip install setuptools wheel
           make install
           make build
         env:

--- a/.github/workflows/build-workspace-product-part.yml
+++ b/.github/workflows/build-workspace-product-part.yml
@@ -252,8 +252,7 @@ jobs:
         run: |
           cd "./tmp/$COMPONENT"
           ls -lah
-          python -m pip install --upgrade pip uv
-          uv pip install setuptools wheel
+          python -m pip install --upgrade pip uv setuptools wheel
           mkdir -p ./build/source
           mkdir -p ./dist_python/
           cd "$DEFAULT_APP"

--- a/.github/workflows/build-workspace-product-part.yml
+++ b/.github/workflows/build-workspace-product-part.yml
@@ -252,8 +252,8 @@ jobs:
         run: |
           cd "./tmp/$COMPONENT"
           ls -lah
-          python -m pip install --upgrade pip
-          pip install setuptools wheel
+          python -m pip install --upgrade pip uv
+          uv pip install setuptools wheel
           mkdir -p ./build/source
           mkdir -p ./dist_python/
           cd "$DEFAULT_APP"

--- a/.github/workflows/build-workspace-product-part.yml
+++ b/.github/workflows/build-workspace-product-part.yml
@@ -252,7 +252,8 @@ jobs:
         run: |
           cd "./tmp/$COMPONENT"
           ls -lah
-          python -m pip install --upgrade pip uv setuptools wheel
+          python -m pip install --upgrade pip uv
+          uv pip install setuptools wheel --system
           mkdir -p ./build/source
           mkdir -p ./dist_python/
           cd "$DEFAULT_APP"


### PR DESCRIPTION
Install uv by default, an extremely fast pip alternative: https://github.com/astral-sh/uv. It is practically a drop-in replacement for pip (just prefix uv, i.e. uv pip install ...). Everyone should install it locally via `pip install --upgrade uv`. 

This PR disables pip cache as we have seen that storing and restoring the pip cache usually takes more time than just resolving it...

In your Makefiles, migrate your Makefile install and develop scripts to this (but pip install will still work just fine)

```
.PHONY: install  ## Install the requirements
install:
	@if [ ! -z "${CI}" ]; then \
		uv pip install -e . --system; \
	else \
		uv pip install -e .; \
	fi

.PHONY: develop  ## Set up the development environment
develop:
	@if [ ! -z "${CI}" ]; then \
		uv pip install -e ".[develop]" --system; \
	else \
		uv pip install -e ".[develop]"; \
	fi
```