### PR TITLE
Feat: add git-lfs flag

### DIFF
--- a/.github/workflows/build-node-python.yml
+++ b/.github/workflows/build-node-python.yml
@@ -358,6 +358,8 @@ jobs:
           token: ${{ github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN  || github.token  }}
           fetch-depth: ${{ inputs.chromatic_enable && '0' || '1' }}
           lfs: true
+      - name: Checkout LFS objects
+        run: git lfs checkout
       - name: Checkout github-workflows
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-node-python.yml
+++ b/.github/workflows/build-node-python.yml
@@ -351,6 +351,8 @@ jobs:
         run: |
           echo "POSTGRES_HOSTNAME=localhost" >> "$GITHUB_ENV"
           echo "POSTGRES_PORT=${{ job.services.postgres.ports['5432'] }}" >> "$GITHUB_ENV"
+      - name: Install git-lfs
+        run: apt-get update && apt-get install git-lfs
       - name: Checkout source repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-node-python.yml
+++ b/.github/workflows/build-node-python.yml
@@ -8,6 +8,11 @@ on:
         required: false
         # When using github.ref || github.head_ref, it would contain the full path, including /, which breaks the postgres hostname
         default: ${{ github.sha }}
+      enable_lfs:
+        description: "Enable git-lfs for the checkout"
+        type: boolean
+        required: false
+        default: false
       cypress_enable:
         description: "Global enable for cypress"
         type: boolean
@@ -123,12 +128,19 @@ jobs:
       contents: write
     runs-on: ${{ inputs.runs_on || 'ubuntu-22.04' }}
     steps:
+      - name: Install git-lfs
+        if: ${{ inputs.enable_lfs }}
+        run: sudo apt-get update && sudo apt-get install -y git-lfs && sudo git lfs install
       - name: Checkout source repository
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
           token: ${{ github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN  || github.token  }}
           fetch-depth: ${{ inputs.chromatic_enable && '0' || '1' }}
+          lfs: ${{ inputs.enable_lfs }}
+      - name: Checkout LFS objects
+        if: ${{ inputs.enable_lfs }}
+        run: git lfs checkout
       - name: Checkout github-workflows
         uses: actions/checkout@v4
         with:
@@ -162,11 +174,18 @@ jobs:
       contents: write
     runs-on: ${{ inputs.runs_on || 'ubuntu-22.04' }}
     steps:
+      - name: Install git-lfs
+        if: ${{ inputs.enable_lfs }}
+        run: sudo apt-get update && sudo apt-get install -y git-lfs && sudo git lfs install
       - name: Checkout source repository
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
           token: ${{ github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN  || github.token  }}
+          lfs: ${{ inputs.enable_lfs }}
+      - name: Checkout LFS objects
+        if: ${{ inputs.enable_lfs }}
+        run: git lfs checkout
       - name: Checkout github-workflows
         uses: actions/checkout@v4
         with:
@@ -232,12 +251,19 @@ jobs:
         run: |
           echo "POSTGRES_HOSTNAME=localhost" >> "$GITHUB_ENV"
           echo "POSTGRES_PORT=${{ job.services.postgres.ports['5432'] }}" >> "$GITHUB_ENV"
+      - name: Install git-lfs
+        if: ${{ inputs.enable_lfs }}
+        run: sudo apt-get update && sudo apt-get install -y git-lfs && sudo git lfs install
       - name: Checkout source repository
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
           token: ${{ github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN  || github.token  }}
           fetch-depth: ${{ inputs.chromatic_enable && '0' || '1' }}
+          lfs: ${{ inputs.enable_lfs }}
+      - name: Checkout LFS objects
+        if: ${{ inputs.enable_lfs }}
+        run: git lfs checkout
       - name: Checkout github-workflows
         uses: actions/checkout@v4
         with:
@@ -352,15 +378,17 @@ jobs:
           echo "POSTGRES_HOSTNAME=localhost" >> "$GITHUB_ENV"
           echo "POSTGRES_PORT=${{ job.services.postgres.ports['5432'] }}" >> "$GITHUB_ENV"
       - name: Install git-lfs
+        if: ${{ inputs.enable_lfs }}
         run: sudo apt-get update && sudo apt-get install -y git-lfs && sudo git lfs install
       - name: Checkout source repository
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
-          token: ${{ github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN  || github.token  }}
+          token: ${{ github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN || github.token  }}
           fetch-depth: ${{ inputs.chromatic_enable && '0' || '1' }}
-          lfs: true
+          lfs: ${{ inputs.enable_lfs }}
       - name: Checkout LFS objects
+        if: ${{ inputs.enable_lfs }}
         run: git lfs checkout
       - name: Checkout github-workflows
         uses: actions/checkout@v4

--- a/.github/workflows/build-node-python.yml
+++ b/.github/workflows/build-node-python.yml
@@ -28,7 +28,7 @@ on:
         description: "Value for the `--spec` parameter. Example: `cypress/e2e/your_spec.cy.ts`. Will only work if cypress_enable: true."
         type: string
         required: false
-        default: ''
+        default: ""
       playwright_enable:
         description: "Global enable for playwright"
         type: boolean
@@ -44,7 +44,7 @@ on:
         # TODO: actionlint is failing as it expects true/false as default value for boolean types
         type: string
         required: false
-        default: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || !!startsWith(github.ref, 'refs/heads/release-') || !!startsWith(github.ref, 'refs/heads/dependabot')}}  
+        default: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || !!startsWith(github.ref, 'refs/heads/release-') || !!startsWith(github.ref, 'refs/heads/dependabot')}}
       playwright_spec_param:
         type: string
         description: "Run specific test(s). Example: `landing-page.spec.ts`"
@@ -77,11 +77,11 @@ on:
         description: Unique id per workflow run. Must be set to unique value if dispatched multiple times for a single workflow.
         default: ""
       chromatic_enable:
-        description: 'Enable Chromatic tests'
+        description: "Enable Chromatic tests"
         required: false
         type: boolean
         default: false
-      
+
     secrets:
       DATAVISYN_BOT_REPO_TOKEN:
         required: false
@@ -340,7 +340,7 @@ jobs:
         run: echo "GH_ACTIONS_SELF_HOSTED_NETWORK_NAME=${GH_ACTIONS_SELF_HOSTED_NETWORK_NAME}" >> "$GITHUB_ENV"
       - name: Set github token, hostname, port and docker network for self-hosted runner
         if: env.GH_ACTIONS_SELF_HOSTED_NETWORK_NAME != ''
-        run: | 
+        run: |
           {
             echo "POSTGRES_HOSTNAME=postgres_${{ github.job }}_${{ inputs.deduplication_id }}_${{ github.run_id }}_${{ github.run_attempt }}"
             echo "POSTGRES_PORT=5432"
@@ -357,6 +357,7 @@ jobs:
           ref: ${{ inputs.branch }}
           token: ${{ github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN  || github.token  }}
           fetch-depth: ${{ inputs.chromatic_enable && '0' || '1' }}
+          lfs: true
       - name: Checkout github-workflows
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-node-python.yml
+++ b/.github/workflows/build-node-python.yml
@@ -352,7 +352,7 @@ jobs:
           echo "POSTGRES_HOSTNAME=localhost" >> "$GITHUB_ENV"
           echo "POSTGRES_PORT=${{ job.services.postgres.ports['5432'] }}" >> "$GITHUB_ENV"
       - name: Install git-lfs
-        run: apt-get update && apt-get install git-lfs
+        run: sudo apt-get update && apt-get install git-lfs
       - name: Checkout source repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-node-python.yml
+++ b/.github/workflows/build-node-python.yml
@@ -352,7 +352,7 @@ jobs:
           echo "POSTGRES_HOSTNAME=localhost" >> "$GITHUB_ENV"
           echo "POSTGRES_PORT=${{ job.services.postgres.ports['5432'] }}" >> "$GITHUB_ENV"
       - name: Install git-lfs
-        run: sudo apt-get update && apt-get install git-lfs
+        run: sudo apt-get update && sudo apt-get install -y git-lfs && sudo git lfs install
       - name: Checkout source repository
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Adding git lfs flag to the build-node-python workflow, as we need to fetch some db dump from git lfs to set up the test database in the CI.