### PR TITLE
Remove unused files in single product build

### DIFF
--- a/.github/workflows/build-product.yml
+++ b/.github/workflows/build-product.yml
@@ -90,7 +90,7 @@ jobs:
       fail-fast: true
       matrix:
         component: ${{fromJson(needs.prepare-build.outputs.components)}}
-    uses: datavisyn/github-workflows/.github/workflows/build-single-product-part.yml@main
+    uses: datavisyn/github-workflows/.github/workflows/build-single-product-part.yml@free_disk_space
     with:
       component: ${{ matrix.component }}
       image_tag1: ${{ needs.prepare-build.outputs.image_tag1 }}

--- a/.github/workflows/build-product.yml
+++ b/.github/workflows/build-product.yml
@@ -90,7 +90,7 @@ jobs:
       fail-fast: true
       matrix:
         component: ${{fromJson(needs.prepare-build.outputs.components)}}
-    uses: datavisyn/github-workflows/.github/workflows/build-single-product-part.yml@free_disk_space
+    uses: datavisyn/github-workflows/.github/workflows/build-single-product-part.yml@main
     with:
       component: ${{ matrix.component }}
       image_tag1: ${{ needs.prepare-build.outputs.image_tag1 }}

--- a/.github/workflows/build-single-product-part.yml
+++ b/.github/workflows/build-single-product-part.yml
@@ -58,6 +58,11 @@ jobs:
   build-components:
     runs-on: ubuntu-22.04
     steps:
+      - name: Remove unnecessary files
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
       # checkout specific repository
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Remove dotnet, android and ghc to free disk space required to build our images. See https://github.com/actions/runner-images/issues/2840#issuecomment-790492173 for details.