### PR TITLE
feat: switch to PGVector 16 as main postgres db

### DIFF
--- a/.github/actions/build-node-python/action.yml
+++ b/.github/actions/build-node-python/action.yml
@@ -124,6 +124,7 @@ runs:
       run: |
         sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
         sudo apt-get install postgresql-16-pgvector
+      shell: bash
     # General
     - name: Git config
       if: inputs.github_ro_token != ''

--- a/.github/actions/build-node-python/action.yml
+++ b/.github/actions/build-node-python/action.yml
@@ -119,6 +119,11 @@ runs:
         pip --version
         uv --version
       shell: bash
+    - name: Install pgvector
+      if: inputs.enable_python == 'true'
+      run: |
+        sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
+        sudo apt-get install postgresql-16-pgvector
     # General
     - name: Git config
       if: inputs.github_ro_token != ''

--- a/.github/actions/build-node-python/action.yml
+++ b/.github/actions/build-node-python/action.yml
@@ -123,7 +123,7 @@ runs:
       if: inputs.enable_python == 'true'
       run: |
         sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
-        sudo apt-get install postgresql-16-pgvector
+        sudo apt-get install postgresql-16-pgvector -y
       shell: bash
     # General
     - name: Git config

--- a/.github/workflows/build-node-python.yml
+++ b/.github/workflows/build-node-python.yml
@@ -201,7 +201,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:14
+        image: pgvector/pgvector:pg16
         env:
           POSTGRES_USER: admin
           POSTGRES_PASSWORD: admin
@@ -340,7 +340,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:14
+        image: pgvector/pgvector:pg16
         env:
           POSTGRES_USER: admin
           POSTGRES_PASSWORD: admin

--- a/.github/workflows/build-node-python.yml
+++ b/.github/workflows/build-node-python.yml
@@ -102,7 +102,7 @@ env:
   PYPI_REGISTRY: "https://upload.pypi.org/legacy/"
   PYPI_USERNAME: "datavisyn"
   PYTHON_VERSION: "3.10"
-  WORKFLOW_BRANCH: "main"
+  WORKFLOW_BRANCH: "pgvector_16"
   POSTGRES_HOSTNAME: postgres_${{ github.job }}_${{ inputs.deduplication_id }}_${{ github.run_id }}_${{ github.run_attempt }}
 
 permissions:

--- a/.github/workflows/build-node-python.yml
+++ b/.github/workflows/build-node-python.yml
@@ -102,7 +102,7 @@ env:
   PYPI_REGISTRY: "https://upload.pypi.org/legacy/"
   PYPI_USERNAME: "datavisyn"
   PYTHON_VERSION: "3.10"
-  WORKFLOW_BRANCH: "pgvector_16"
+  WORKFLOW_BRANCH: "main"
   POSTGRES_HOSTNAME: postgres_${{ github.job }}_${{ inputs.deduplication_id }}_${{ github.run_id }}_${{ github.run_attempt }}
 
 permissions:


### PR DESCRIPTION
We need PGVector for some LLM features and would simply switch to their Docker image as outlined here: https://github.com/pgvector/setup-pgvector

This also includes a version bump from v14 to v16, but shouldn't break anything because we already were running on Ubuntu 22.04, installing v16 for pytest for example.