### PR TITLE
fix: correct version for changelog

### DIFF
--- a/.github/workflows/release-source.yml
+++ b/.github/workflows/release-source.yml
@@ -227,12 +227,13 @@ jobs:
       - name: Generate release notes
         id: generate-release-notes
         run: |
+          TAG_NAME="v${{ inputs.release_version }}"
           response=$(curl -s -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/releases/generate-notes \
-            -d "$(jq -n --arg tag_name "${{ env.RELEASE_VERSION }}" \
+            -d "$(jq -n --arg tag_name "$TAG_NAME" \
                   --arg target_commitish "${{ github.ref_name }}" \
                   '{tag_name: $tag_name, target_commitish: $target_commitish}')")
           


### PR DESCRIPTION
From Holger:
I noticed that the changelog generated by the release action contains a broken link, due to a typo. Take [this aevidence release](https://github.com/datavisyn/aevidence/releases/tag/v21.1.0) as an example, which contains the following footer:
Full Changelog: [v21.0.0...21.1.0](https://github.com/datavisyn/aevidence/compare/v21.0.0...21.1.0)
The link to the changelog is broken, because it misses the v for the second version number/tag. The correct link would be:
Full Changelog: [v21.0.0...v21.1.0](https://github.com/datavisyn/aevidence/compare/v21.0.0...v21.1.0)
I couldn't find the place where to fix this typo. Could you please correct it? :thx:


Fixed and tested successfully with test-app.