### PR TITLE
ci: add 60 min default timeout for jobs

### DIFF
--- a/.github/workflows/build-node-python.yml
+++ b/.github/workflows/build-node-python.yml
@@ -81,6 +81,11 @@ on:
         required: false
         type: boolean
         default: false
+      timeout:
+        description: "Timeout for each job in minutes."
+        type: number
+        required: false
+        default: 60
       
     secrets:
       DATAVISYN_BOT_REPO_TOKEN:
@@ -114,6 +119,7 @@ permissions:
 jobs:
   build-node:
     name: Node
+    timeout-minutes: ${{ fromJSON(inputs.timeout) }}
     if: ${{ (!inputs.cypress_enable || (!inputs.cypress_run_because_flag && inputs.cypress_run_because_branch != 'true')) && (!inputs.playwright_enable || (!inputs.playwright_run_because_flag && inputs.playwright_run_because_branch != 'true')) }}
     concurrency:
       group: "node-${{ github.workflow }}-${{ github.ref || github.head_ref }}-${{ inputs.branch }}"
@@ -153,6 +159,7 @@ jobs:
 
   build-python:
     name: Python
+    timeout-minutes: ${{ fromJSON(inputs.timeout) }}
     if: ${{ (!inputs.cypress_enable || (!inputs.cypress_run_because_flag && inputs.cypress_run_because_branch != 'true')) && (!inputs.playwright_enable || (!inputs.playwright_run_because_flag && inputs.playwright_run_because_branch != 'true')) }}
     concurrency:
       group: "python-${{ github.workflow }}-${{ github.ref || github.head_ref }}-${{ inputs.branch }}"
@@ -190,6 +197,7 @@ jobs:
   # If cypress is used, build node and python sequentially as it is avoiding the duplicate install overhead
   build-node-python-cypress:
     name: Node, Python, Cypress
+    timeout-minutes: ${{ fromJSON(inputs.timeout) }}
     if: ${{ inputs.cypress_enable && (inputs.cypress_run_because_flag || inputs.cypress_run_because_branch == 'true') }}
     concurrency:
       group: "node-python-cypress-${{ github.workflow }}-${{ github.ref || github.head_ref }}-${{ inputs.branch }}"
@@ -329,6 +337,7 @@ jobs:
   # If playwright is used, build node and python sequentially as it is avoiding the duplicate install overhead
   build-node-python-playwright:
     name: Node, Python, Playwright
+    timeout-minutes: ${{ fromJSON(inputs.timeout) }}
     if: ${{ inputs.playwright_enable && (inputs.playwright_run_because_flag || inputs.playwright_run_because_branch == 'true') }}
     concurrency:
       group: "node-python-playwright-${{ github.workflow }}-${{ github.ref || github.head_ref }}-${{ inputs.branch }}"

--- a/.github/workflows/build-single-product-part.yml
+++ b/.github/workflows/build-single-product-part.yml
@@ -41,6 +41,11 @@ on:
           description: "stage for the image (develop or production) depending on the branch name"
           required: true
           type: string
+        timeout:
+          description: "Timeout for each job in minutes."
+          type: number
+          required: false
+          default: 60
 env:
   TIME_ZONE: "Europe/Vienna"
   NODE_VERSION: "20.9"
@@ -56,6 +61,7 @@ permissions:
 
 jobs:
   build-components:
+    timeout-minutes: ${{ fromJSON(inputs.timeout) }}
     runs-on: ubuntu-22.04
     steps:
       - name: Remove unnecessary files

--- a/.github/workflows/build-workspace-product-part.yml
+++ b/.github/workflows/build-workspace-product-part.yml
@@ -38,6 +38,11 @@ on:
           description: "stage for the image (develop or production) depending on the branch name"
           required: true
           type: string
+        timeout:
+          description: "Timeout for each job in minutes."
+          type: number
+          required: false
+          default: 60
 env:
   VISYN_SCRIPTS_VERSION: "v7" # visyn_scripts@v7 is the last version with workspace support
   TIME_ZONE: "Europe/Vienna"
@@ -54,6 +59,7 @@ permissions:
 
 jobs:
   build-components:
+    timeout-minutes: ${{ fromJSON(inputs.timeout) }}
     runs-on: ubuntu-22.04
     steps:
       # checkout specific repository

--- a/.github/workflows/deploy-product.yml
+++ b/.github/workflows/deploy-product.yml
@@ -22,6 +22,11 @@ on:
         required: false
         type: boolean
         default: false
+      timeout:
+        description: "Timeout for each job in minutes."
+        type: number
+        required: false
+        default: 60
     outputs:
       revision_label:
         description: "revision that is stored as a label"
@@ -42,6 +47,7 @@ env:
 
 jobs:
   deploy:
+    timeout-minutes: ${{ fromJSON(inputs.timeout) }}
     runs-on: ubuntu-22.04
     outputs:
       revision_label: ${{ steps.get-revision-label.outputs.revision_label }}


### PR DESCRIPTION
instead of the default 6h timeout

tested it by [building aevidence](https://github.com/datavisyn/aevidence/actions/runs/12806914486)