### PR TITLE
feat: remove skip scan option and add scan_high_severity flag

### DIFF
--- a/.github/workflows/build-docker-artifacts-config.schema.json
+++ b/.github/workflows/build-docker-artifacts-config.schema.json
@@ -35,10 +35,10 @@
                       "type": "string",
                       "description": "ECR repository to push the image to"
                     },
-                    "skip_image_scan": {
+                    "scan_high_severity": {
                       "type": "boolean",
-                      "default": false,
-                      "description": "Skip scanning the image for vulnerabilities"
+                      "default": true,
+                      "description": "Scan the image for high severity vulnerabilities"
                     }
                   },
                   "required": ["directory", "ecr_repository"]

--- a/.github/workflows/build-docker-artifacts.yml
+++ b/.github/workflows/build-docker-artifacts.yml
@@ -22,10 +22,11 @@ on:
         type: boolean
         required: false
         default: true
-      skip_image_scan:
+      scan_high_severity:
+        description: 'Include high severity'
         type: boolean
         required: false
-        default: false
+        default: true
       runs_on:
         type: string
         required: false
@@ -240,8 +241,15 @@ jobs:
           # https://github.com/docker/build-push-action/issues/1156#issuecomment-2437227730
           DOCKER_BUILD_SUMMARY: false
 
+      - name: Determine trivy scan severity levels
+        id: set_severity
+        run: |
+          if [[ ${{ inputs.scan_high_severity }} != true ]]; then
+            echo "severity=CRITICAL" >> $GITHUB_OUTPUT
+          else
+            echo "severity=HIGH,CRITICAL" >> $GITHUB_OUTPUT
+          fi
       - name: Run Trivy vulnerability scanner
-        if: ${{ inputs.skip_image_scan != true && fromJson(vars.SKIP_IMAGE_SCAN || 'false') != true && matrix.component.skip_image_scan != true }}
         uses: aquasecurity/trivy-action@0.30.0
         with:
           image-ref: ${{ vars.DV_AWS_ECR_REGISTRY }}/${{ matrix.component.ecr_repository }}:${{ matrix.component.image_tag }}
@@ -249,7 +257,7 @@ jobs:
           exit-code: '1'
           ignore-unfixed: false
           vuln-type: 'os,library'
-          severity: 'HIGH,CRITICAL'
+          severity: ${{ steps.set_severity.outputs.severity }}
         continue-on-error: false 
 
       - name: Push image


### PR DESCRIPTION
### Summary

* Skipping the entire trivy scan is no longer possible
* Set `scan_high_severity` flag to false to avoid build failure due to detection of high vulnerabilities