### PR TITLE
fix: remove github sha from concurrency group to cancel commits on the same branch

### DIFF
--- a/.github/workflows/build-docker-artifacts-trigger-push.yml
+++ b/.github/workflows/build-docker-artifacts-trigger-push.yml
@@ -11,8 +11,6 @@ on:
       branch:
         type: string
         required: false
-        # When using github.ref || github.head_ref, it would contain the full path, including /, which breaks the postgres hostname
-        default: ${{ github.sha }}
       runs_on:
         type: string
         required: false
@@ -47,7 +45,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch }}
+          ref: ${{ inputs.branch || github.sha }}
           token: ${{ secrets.CHECKOUT_TOKEN || github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN || github.token }}
 
       - name: Checkout github-workflows repository

--- a/.github/workflows/build-docker-artifacts.yml
+++ b/.github/workflows/build-docker-artifacts.yml
@@ -16,8 +16,6 @@ on:
       branch:
         type: string
         required: false
-        # When using github.ref || github.head_ref, it would contain the full path, including /, which breaks the postgres hostname
-        default: ${{ github.sha }}
       skip_push:
         type: boolean
         required: false
@@ -69,7 +67,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch }}
+          ref: ${{ inputs.branch || github.sha }}
           token: ${{ secrets.CHECKOUT_TOKEN || github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN || github.token }}
 
       - name: Checkout github-workflows repository
@@ -165,7 +163,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch }}
+          ref: ${{ inputs.branch || github.sha }}
           token: ${{ secrets.CHECKOUT_TOKEN || github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN || github.token }}
           # This is required such that yarn install can access private repositories, i.e. visyn_pro
           # https://github.com/yarnpkg/yarn/issues/2614#issuecomment-2148174789
@@ -294,7 +292,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch }}
+          ref: ${{ inputs.branch || github.sha }}
           token: ${{ secrets.CHECKOUT_TOKEN || github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN || github.token }}
 
       - name: Checkout github-workflows repository
@@ -348,6 +346,6 @@ jobs:
     secrets: inherit
     with:
       push_to: ${{ fromJson(needs.get-flavors.outputs.result).push_to }}
-      branch: ${{ inputs.branch }}
+      branch: ${{ inputs.branch || github.sha }}
       # Do not run this on self-hosted, as it is faster and shouldn't be blocking anything
       # runs_on: ${{ inputs.runs_on || 'ubuntu-22.04' }}

--- a/.github/workflows/build-node-python.yml
+++ b/.github/workflows/build-node-python.yml
@@ -6,8 +6,6 @@ on:
       branch:
         type: string
         required: false
-        # When using github.ref || github.head_ref, it would contain the full path, including /, which breaks the postgres hostname
-        default: ${{ github.sha }}
       cypress_enable:
         description: "Global enable for cypress"
         type: boolean
@@ -132,7 +130,7 @@ jobs:
       - name: Checkout source repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch }}
+          ref: ${{ inputs.branch || github.sha }}
           token: ${{ github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN  || github.token  }}
           fetch-depth: ${{ inputs.chromatic_enable && '0' || '1' }}
       - name: Checkout github-workflows
@@ -172,7 +170,7 @@ jobs:
       - name: Checkout source repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch }}
+          ref: ${{ inputs.branch || github.sha }}
           token: ${{ github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN  || github.token  }}
       - name: Checkout github-workflows
         uses: actions/checkout@v4
@@ -263,7 +261,7 @@ jobs:
       - name: Checkout source repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch }}
+          ref: ${{ inputs.branch || github.sha }}
           token: ${{ github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN  || github.token  }}
           fetch-depth: ${{ inputs.chromatic_enable && '0' || '1' }}
       - name: Checkout github-workflows
@@ -405,7 +403,7 @@ jobs:
       - name: Checkout source repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch }}
+          ref: ${{ inputs.branch || github.sha }}
           token: ${{ github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN  || github.token  }}
           fetch-depth: ${{ inputs.chromatic_enable && '0' || '1' }}
       - name: Checkout github-workflows
@@ -447,13 +445,13 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: "bundles-${{ inputs.branch }}"
+          name: "bundles-${{ inputs.branch || github.sha }}"
           path: bundles/
       - name: Upload playwright report
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: "playwright-report-${{ inputs.branch }}"
+          name: "playwright-report-${{ inputs.branch || github.sha }}"
           path: playwright-report/
       - name: Run Chromatic Playwright
         if: ${{ inputs.chromatic_enable }}


### PR DESCRIPTION
Previously, the github sha made it impossible to cancel the same workflows on the same branches, causing many "duplicate" runs: 

<img width="2562" height="612" alt="image" src="https://github.com/user-attachments/assets/893d351a-3917-4543-a3d4-533277c5d059" />

In this case, only two should have run, as the other two should have been cancelled. 