### PR TITLE
feat: add ability to set PYTHON_VERSION and NODE_VERSION via variables and inputs

### DIFF
--- a/.github/workflows/build-node-python.yml
+++ b/.github/workflows/build-node-python.yml
@@ -115,10 +115,10 @@ on:
 
 env:
   NPM_REGISTRY: "https://registry.npmjs.org/"
-  NODE_VERSION: ${{ vars.NODE_VERSION || "3.10" }}
+  NODE_VERSION: ${{ vars.NODE_VERSION || '20.9' }}
   PYPI_REGISTRY: "https://upload.pypi.org/legacy/"
   PYPI_USERNAME: "datavisyn"
-  PYTHON_VERSION: ${{ vars.PYTHON_VERSION || "3.10" }}
+  PYTHON_VERSION: ${{ vars.PYTHON_VERSION || '3.10' }}
   WORKFLOW_BRANCH: "main"
   POSTGRES_HOSTNAME: postgres_${{ github.job }}_${{ inputs.deduplication_id }}_${{ github.run_id }}_${{ github.run_attempt }}
 

--- a/.github/workflows/build-node-python.yml
+++ b/.github/workflows/build-node-python.yml
@@ -112,7 +112,7 @@ env:
   NODE_VERSION: "20.9"
   PYPI_REGISTRY: "https://upload.pypi.org/legacy/"
   PYPI_USERNAME: "datavisyn"
-  PYTHON_VERSION: "3.10"
+  PYTHON_VERSION: ${{ vars.PYTHON_VERSION || "3.10" }}
   WORKFLOW_BRANCH: "main"
   POSTGRES_HOSTNAME: postgres_${{ github.job }}_${{ inputs.deduplication_id }}_${{ github.run_id }}_${{ github.run_attempt }}
 

--- a/.github/workflows/build-node-python.yml
+++ b/.github/workflows/build-node-python.yml
@@ -163,7 +163,7 @@ jobs:
           run_parallel: ${{ inputs.run_parallel }}
           node_version: ${{ inputs.node_version || secrets.NODE_VERSION || env.NODE_VERSION }}
           npm_registry: ${{ env.NPM_REGISTRY }}
-          python_version: ${{ inputs.python_version || inputs.python_version || secrets.PYTHON_VERSION || env.PYTHON_VERSION }}
+          python_version: ${{ inputs.python_version || secrets.PYTHON_VERSION || env.PYTHON_VERSION }}
           github_ro_token: ${{ github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN || github.token  }}
           run_node_bundle: ${{ inputs.node_run_webpack }}
           enable_node_cache: ${{ inputs.runs_on != 'self-hosted' }}

--- a/.github/workflows/build-node-python.yml
+++ b/.github/workflows/build-node-python.yml
@@ -161,7 +161,7 @@ jobs:
           # We probably won't need Rust on Node builds...
           # enable_rust: ${{ inputs.rust_enable }}
           run_parallel: ${{ inputs.run_parallel }}
-          node_version: ${{ inputs.node_version || inputs.node_version || secrets.NODE_VERSION || env.NODE_VERSION }}
+          node_version: ${{ inputs.node_version || secrets.NODE_VERSION || env.NODE_VERSION }}
           npm_registry: ${{ env.NPM_REGISTRY }}
           python_version: ${{ inputs.python_version || inputs.python_version || secrets.PYTHON_VERSION || env.PYTHON_VERSION }}
           github_ro_token: ${{ github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN || github.token  }}

--- a/.github/workflows/build-node-python.yml
+++ b/.github/workflows/build-node-python.yml
@@ -92,7 +92,13 @@ on:
         type: number
         required: false
         default: 60
-      
+      python_version:
+        type: string
+        required: false
+      node_version:
+        type: string
+        required: false
+
     secrets:
       DATAVISYN_BOT_REPO_TOKEN:
         required: false
@@ -109,7 +115,7 @@ on:
 
 env:
   NPM_REGISTRY: "https://registry.npmjs.org/"
-  NODE_VERSION: "20.9"
+  NODE_VERSION: ${{ vars.NODE_VERSION || "3.10" }}
   PYPI_REGISTRY: "https://upload.pypi.org/legacy/"
   PYPI_USERNAME: "datavisyn"
   PYTHON_VERSION: ${{ vars.PYTHON_VERSION || "3.10" }}
@@ -155,9 +161,9 @@ jobs:
           # We probably won't need Rust on Node builds...
           # enable_rust: ${{ inputs.rust_enable }}
           run_parallel: ${{ inputs.run_parallel }}
-          node_version: ${{ secrets.NODE_VERSION || env.NODE_VERSION }}
+          node_version: ${{ inputs.node_version || inputs.node_version || secrets.NODE_VERSION || env.NODE_VERSION }}
           npm_registry: ${{ env.NPM_REGISTRY }}
-          python_version: ${{ secrets.PYTHON_VERSION || env.PYTHON_VERSION }}
+          python_version: ${{ inputs.python_version || inputs.python_version || secrets.PYTHON_VERSION || env.PYTHON_VERSION }}
           github_ro_token: ${{ github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN || github.token  }}
           run_node_bundle: ${{ inputs.node_run_webpack }}
           enable_node_cache: ${{ inputs.runs_on != 'self-hosted' }}
@@ -195,9 +201,9 @@ jobs:
           enable_python: true
           enable_rust: ${{ inputs.rust_enable }}
           run_parallel: ${{ inputs.run_parallel }}
-          node_version: ${{ secrets.NODE_VERSION || env.NODE_VERSION }}
+          node_version: ${{ inputs.node_version || secrets.NODE_VERSION || env.NODE_VERSION }}
           npm_registry: ${{ env.NPM_REGISTRY }}
-          python_version: ${{ secrets.PYTHON_VERSION || env.PYTHON_VERSION }}
+          python_version: ${{ inputs.python_version || secrets.PYTHON_VERSION || env.PYTHON_VERSION }}
           github_ro_token: ${{ github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN || github.token  }}
           run_node_bundle: ${{ inputs.node_run_webpack }}
           enable_node_cache: ${{ inputs.runs_on != 'self-hosted' }}
@@ -286,9 +292,9 @@ jobs:
         with:
           enable_rust: ${{ inputs.rust_enable }}
           run_parallel: ${{ inputs.run_parallel }}
-          node_version: ${{ secrets.NODE_VERSION || env.NODE_VERSION }}
+          node_version: ${{ inputs.node_version || secrets.NODE_VERSION || env.NODE_VERSION }}
           npm_registry: ${{ env.NPM_REGISTRY }}
-          python_version: ${{ secrets.PYTHON_VERSION || env.PYTHON_VERSION }}
+          python_version: ${{ inputs.python_version || secrets.PYTHON_VERSION || env.PYTHON_VERSION }}
           github_ro_token: ${{ github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN || github.token  }}
           run_node_bundle: false # Disable the build here and call afterwards, as otherwise the yarn run env:decrypt will fail due to a missing yarn install
           enable_node_cache: ${{ inputs.cypress_runs_on != 'self-hosted' && inputs.runs_on != 'self-hosted' }}
@@ -429,9 +435,9 @@ jobs:
         with:
           enable_rust: ${{ inputs.rust_enable }}
           run_parallel: ${{ inputs.run_parallel }}
-          node_version: ${{ secrets.NODE_VERSION || env.NODE_VERSION }}
+          node_version: ${{ inputs.node_version || secrets.NODE_VERSION || env.NODE_VERSION }}
           npm_registry: ${{ env.NPM_REGISTRY }}
-          python_version: ${{ secrets.PYTHON_VERSION || env.PYTHON_VERSION }}
+          python_version: ${{ inputs.python_version || secrets.PYTHON_VERSION || env.PYTHON_VERSION }}
           github_ro_token: ${{ github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN || github.token  }}
           run_node_bundle: false # Disable the build here and call afterwards, as otherwise the yarn run env:decrypt will fail due to a missing yarn install
           run_playwright_browser_install: true

--- a/.github/workflows/build-node.yml
+++ b/.github/workflows/build-node.yml
@@ -21,6 +21,10 @@ on:
         type: string
         required: false
         default: "ubuntu-22.04"
+      node_version:
+        type: string
+        required: false
+
     secrets:
       DATAVISYN_BOT_REPO_TOKEN:
         required: false
@@ -31,7 +35,7 @@ on:
 
 env:
   NPM_REGISTRY: "https://registry.npmjs.org/"
-  NODE_VERSION: "20.9"
+  NODE_VERSION: ${{ vars.NODE_VERSION || "3.10" }}
   WORKFLOW_BRANCH: "main"
 
 permissions:
@@ -69,7 +73,7 @@ jobs:
         with:
           enable_node: true
           enable_python: false
-          node_version: ${{ secrets.NODE_VERSION || env.NODE_VERSION }}
+          node_version: ${{ inputs.node_version || secrets.NODE_VERSION || env.NODE_VERSION }}
           npm_registry: ${{ env.NPM_REGISTRY }}
           github_ro_token: ${{ github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN || github.token  }}
           run_node_bundle: ${{ inputs.node_run_webpack }}

--- a/.github/workflows/build-node.yml
+++ b/.github/workflows/build-node.yml
@@ -35,7 +35,7 @@ on:
 
 env:
   NPM_REGISTRY: "https://registry.npmjs.org/"
-  NODE_VERSION: ${{ vars.NODE_VERSION || "3.10" }}
+  NODE_VERSION: ${{ vars.NODE_VERSION || '20.9' }}
   WORKFLOW_BRANCH: "main"
 
 permissions:

--- a/.github/workflows/build-product.yml
+++ b/.github/workflows/build-product.yml
@@ -31,7 +31,7 @@ concurrency:
 env:
   TIME_ZONE: "Europe/Vienna"
   NODE_VERSION: "20.9"
-  PYTHON_VERSION: "3.10"
+  PYTHON_VERSION: ${{ vars.PYTHON_VERSION || "3.10" }}
   WORKFLOW_BRANCH: "main"
   PYTHON_BASE_IMAGE: "python:3.10.18-slim-bullseye"
   DATAVISYN_PYTHON_BASE_IMAGE: "188237246440.dkr.ecr.eu-central-1.amazonaws.com/datavisyn/base/python:main"

--- a/.github/workflows/build-product.yml
+++ b/.github/workflows/build-product.yml
@@ -30,8 +30,8 @@ concurrency:
 
 env:
   TIME_ZONE: "Europe/Vienna"
-  NODE_VERSION: ${{ vars.NODE_VERSION || "3.10" }}
-  PYTHON_VERSION: ${{ vars.PYTHON_VERSION || "3.10" }}
+  NODE_VERSION: ${{ vars.NODE_VERSION || '20.9' }}
+  PYTHON_VERSION: ${{ vars.PYTHON_VERSION || '3.10' }}
   WORKFLOW_BRANCH: "main"
   PYTHON_BASE_IMAGE: "python:3.10.18-slim-bullseye"
   DATAVISYN_PYTHON_BASE_IMAGE: "188237246440.dkr.ecr.eu-central-1.amazonaws.com/datavisyn/base/python:main"

--- a/.github/workflows/build-product.yml
+++ b/.github/workflows/build-product.yml
@@ -30,7 +30,7 @@ concurrency:
 
 env:
   TIME_ZONE: "Europe/Vienna"
-  NODE_VERSION: "20.9"
+  NODE_VERSION: ${{ vars.NODE_VERSION || "3.10" }}
   PYTHON_VERSION: ${{ vars.PYTHON_VERSION || "3.10" }}
   WORKFLOW_BRANCH: "main"
   PYTHON_BASE_IMAGE: "python:3.10.18-slim-bullseye"

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -11,6 +11,10 @@ on:
         type: string
         required: false
         default: "ubuntu-22.04"
+      python_version:
+        type: string
+        required: false
+
     secrets:
       DATAVISYN_BOT_REPO_TOKEN:
         required: false
@@ -58,5 +62,5 @@ jobs:
           enable_node: false
           enable_python: true
           github_ro_token: ${{ github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN || github.token  }}
-          python_version: ${{ secrets.PYTHON_VERSION || env.PYTHON_VERSION }}
+          python_version: ${{ inputs.python_version || secrets.PYTHON_VERSION || env.PYTHON_VERSION }}
           enable_python_cache: ${{ inputs.runs_on != 'self-hosted' }}

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -20,7 +20,7 @@ on:
 env:
   PYPI_REGISTRY: "https://upload.pypi.org/legacy/"
   PYPI_USERNAME: "test"
-  PYTHON_VERSION: "3.10"
+  PYTHON_VERSION: ${{ vars.PYTHON_VERSION || "3.10" }}
   WORKFLOW_BRANCH: "main"
 
 permissions:

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -24,7 +24,7 @@ on:
 env:
   PYPI_REGISTRY: "https://upload.pypi.org/legacy/"
   PYPI_USERNAME: "test"
-  PYTHON_VERSION: ${{ vars.PYTHON_VERSION || "3.10" }}
+  PYTHON_VERSION: ${{ vars.PYTHON_VERSION || '3.10' }}
   WORKFLOW_BRANCH: "main"
 
 permissions:

--- a/.github/workflows/build-single-product-part.yml
+++ b/.github/workflows/build-single-product-part.yml
@@ -52,8 +52,8 @@ on:
           default: "ubuntu-22.04"
 env:
   TIME_ZONE: "Europe/Vienna"
-  NODE_VERSION: ${{ vars.NODE_VERSION || "3.10" }}
-  PYTHON_VERSION: ${{ vars.PYTHON_VERSION || "3.10" }}
+  NODE_VERSION: ${{ vars.NODE_VERSION || '20.9' }}
+  PYTHON_VERSION: ${{ vars.PYTHON_VERSION || '3.10' }}
   WORKFLOW_BRANCH: "main"
   PYTHON_BASE_IMAGE: "python:3.10.18-slim-bullseye"
   DATAVISYN_PYTHON_BASE_IMAGE: "188237246440.dkr.ecr.eu-central-1.amazonaws.com/datavisyn/base/python:main"

--- a/.github/workflows/build-single-product-part.yml
+++ b/.github/workflows/build-single-product-part.yml
@@ -52,7 +52,7 @@ on:
           default: "ubuntu-22.04"
 env:
   TIME_ZONE: "Europe/Vienna"
-  NODE_VERSION: "20.9"
+  NODE_VERSION: ${{ vars.NODE_VERSION || "3.10" }}
   PYTHON_VERSION: ${{ vars.PYTHON_VERSION || "3.10" }}
   WORKFLOW_BRANCH: "main"
   PYTHON_BASE_IMAGE: "python:3.10.18-slim-bullseye"

--- a/.github/workflows/build-single-product-part.yml
+++ b/.github/workflows/build-single-product-part.yml
@@ -53,7 +53,7 @@ on:
 env:
   TIME_ZONE: "Europe/Vienna"
   NODE_VERSION: "20.9"
-  PYTHON_VERSION: "3.10"
+  PYTHON_VERSION: ${{ vars.PYTHON_VERSION || "3.10" }}
   WORKFLOW_BRANCH: "main"
   PYTHON_BASE_IMAGE: "python:3.10.18-slim-bullseye"
   DATAVISYN_PYTHON_BASE_IMAGE: "188237246440.dkr.ecr.eu-central-1.amazonaws.com/datavisyn/base/python:main"

--- a/.github/workflows/build-workspace-product-part.yml
+++ b/.github/workflows/build-workspace-product-part.yml
@@ -18,35 +18,36 @@ on:
       GITLAB_HOST:
         required: false
     inputs:
-        component:
-          description: "component that should be built"
-          required: true
-          type: string
-        image_tag1:
-          description: "image tag 1 to push the image"
-          required: true
-          type: string
-        image_tag2:
-          description: "image tag 2 for labeling"
-          required: true
-          type: string
-        build_time:
-          description: "actually build time (in RFC 3339)"
-          required: true
-          type: string
-        stage:
-          description: "stage for the image (develop or production) depending on the branch name"
-          required: true
-          type: string
-        timeout:
-          description: "Timeout for each job in minutes."
-          type: number
-          required: false
-          default: 60
+      component:
+        description: "component that should be built"
+        required: true
+        type: string
+      image_tag1:
+        description: "image tag 1 to push the image"
+        required: true
+        type: string
+      image_tag2:
+        description: "image tag 2 for labeling"
+        required: true
+        type: string
+      build_time:
+        description: "actually build time (in RFC 3339)"
+        required: true
+        type: string
+      stage:
+        description: "stage for the image (develop or production) depending on the branch name"
+        required: true
+        type: string
+      timeout:
+        description: "Timeout for each job in minutes."
+        type: number
+        required: false
+        default: 60
+
 env:
   VISYN_SCRIPTS_VERSION: "v7" # visyn_scripts@v7 is the last version with workspace support
   TIME_ZONE: "Europe/Vienna"
-  NODE_VERSION: "20.9"
+  NODE_VERSION: ${{ vars.NODE_VERSION || "3.10" }}
   PYTHON_VERSION: ${{ vars.PYTHON_VERSION || "3.10" }}
   WORKFLOW_BRANCH: "main"
   PYTHON_BASE_IMAGE: "python:3.10.18-slim-bullseye"

--- a/.github/workflows/build-workspace-product-part.yml
+++ b/.github/workflows/build-workspace-product-part.yml
@@ -47,7 +47,7 @@ env:
   VISYN_SCRIPTS_VERSION: "v7" # visyn_scripts@v7 is the last version with workspace support
   TIME_ZONE: "Europe/Vienna"
   NODE_VERSION: "20.9"
-  PYTHON_VERSION: "3.10"
+  PYTHON_VERSION: ${{ vars.PYTHON_VERSION || "3.10" }}
   WORKFLOW_BRANCH: "main"
   PYTHON_BASE_IMAGE: "python:3.10.18-slim-bullseye"
   DATAVISYN_PYTHON_BASE_IMAGE: "188237246440.dkr.ecr.eu-central-1.amazonaws.com/datavisyn/base/python:main"

--- a/.github/workflows/build-workspace-product-part.yml
+++ b/.github/workflows/build-workspace-product-part.yml
@@ -47,8 +47,8 @@ on:
 env:
   VISYN_SCRIPTS_VERSION: "v7" # visyn_scripts@v7 is the last version with workspace support
   TIME_ZONE: "Europe/Vienna"
-  NODE_VERSION: ${{ vars.NODE_VERSION || "3.10" }}
-  PYTHON_VERSION: ${{ vars.PYTHON_VERSION || "3.10" }}
+  NODE_VERSION: ${{ vars.NODE_VERSION || '20.9' }}
+  PYTHON_VERSION: ${{ vars.PYTHON_VERSION || '3.10' }}
   WORKFLOW_BRANCH: "main"
   PYTHON_BASE_IMAGE: "python:3.10.18-slim-bullseye"
   DATAVISYN_PYTHON_BASE_IMAGE: "188237246440.dkr.ecr.eu-central-1.amazonaws.com/datavisyn/base/python:main"

--- a/.github/workflows/publish-node-python.yml
+++ b/.github/workflows/publish-node-python.yml
@@ -21,7 +21,7 @@ env:
   NPM_REGISTRY: "https://registry.npmjs.org/"
   PYPI_REGISTRY: "https://upload.pypi.org/legacy/"
   PYPI_USERNAME: "datavisyn"
-  PYTHON_VERSION: "3.10"
+  PYTHON_VERSION: ${{ vars.PYTHON_VERSION || "3.10" }}
   WORKFLOW_BRANCH: "main"
 
 permissions:

--- a/.github/workflows/publish-node-python.yml
+++ b/.github/workflows/publish-node-python.yml
@@ -2,6 +2,14 @@ name: publish-node-python
 
 on:
   workflow_call:
+    inputs:
+      python_version:
+        type: string
+        required: false
+      node_version:
+        type: string
+        required: false
+
     secrets:
       PYPI_USERNAME:
         required: true
@@ -17,7 +25,7 @@ on:
         required: false
 
 env:
-  NODE_VERSION: "20.9"
+  NODE_VERSION: ${{ vars.NODE_VERSION || "3.10" }}
   NPM_REGISTRY: "https://registry.npmjs.org/"
   PYPI_REGISTRY: "https://upload.pypi.org/legacy/"
   PYPI_USERNAME: "datavisyn"
@@ -63,7 +71,7 @@ jobs:
         with:
           enable_node: true
           enable_python: false
-          node_version: ${{ secrets.NODE_VERSION || env.NODE_VERSION }}
+          node_version: ${{ inputs.node_version || secrets.NODE_VERSION || env.NODE_VERSION }}
           npm_registry: ${{ env.NPM_REGISTRY }}
           github_ro_token: ${{ github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN || github.token }}
       - uses: ./tmp/github-workflows/.github/actions/publish-node
@@ -96,7 +104,7 @@ jobs:
         with:
           enable_node: false
           enable_python: true
-          python_version: ${{ secrets.PYTHON_VERSION || env.PYTHON_VERSION }}
+          python_version: ${{ inputs.python_version || secrets.PYTHON_VERSION || env.PYTHON_VERSION }}
           github_ro_token: ${{ github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN || github.token }}
       - uses: ./tmp/github-workflows/.github/actions/publish-python
         with:

--- a/.github/workflows/publish-node-python.yml
+++ b/.github/workflows/publish-node-python.yml
@@ -25,11 +25,11 @@ on:
         required: false
 
 env:
-  NODE_VERSION: ${{ vars.NODE_VERSION || "3.10" }}
+  NODE_VERSION: ${{ vars.NODE_VERSION || '20.9' }}
   NPM_REGISTRY: "https://registry.npmjs.org/"
   PYPI_REGISTRY: "https://upload.pypi.org/legacy/"
   PYPI_USERNAME: "datavisyn"
-  PYTHON_VERSION: ${{ vars.PYTHON_VERSION || "3.10" }}
+  PYTHON_VERSION: ${{ vars.PYTHON_VERSION || '3.10' }}
   WORKFLOW_BRANCH: "main"
 
 permissions:

--- a/.github/workflows/publish-node.yml
+++ b/.github/workflows/publish-node.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   NPM_REGISTRY: "https://registry.npmjs.org/"
-  NODE_VERSION: ${{ vars.NODE_VERSION || "3.10" }}
+  NODE_VERSION: ${{ vars.NODE_VERSION || '20.9' }}
   WORKFLOW_BRANCH: "main"
 
 permissions:

--- a/.github/workflows/publish-node.yml
+++ b/.github/workflows/publish-node.yml
@@ -2,6 +2,11 @@ name: publish-node
 
 on:
   workflow_call:
+    inputs:
+      node_version:
+        type: string
+        required: false
+
     secrets:
       NPM_TOKEN:
         required: true
@@ -12,7 +17,7 @@ on:
 
 env:
   NPM_REGISTRY: "https://registry.npmjs.org/"
-  NODE_VERSION: "20.9"
+  NODE_VERSION: ${{ vars.NODE_VERSION || "3.10" }}
   WORKFLOW_BRANCH: "main"
 
 permissions:
@@ -54,7 +59,7 @@ jobs:
         with:
           enable_node: true
           enable_python: false
-          node_version: ${{ secrets.NODE_VERSION || env.NODE_VERSION }}
+          node_version: ${{ inputs.node_version || secrets.NODE_VERSION || env.NODE_VERSION }}
           npm_registry: ${{ env.NPM_REGISTRY }}
           github_ro_token: ${{ github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN || github.token }}
       - uses: ./tmp/github-workflows/.github/actions/publish-node

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   PYPI_REGISTRY: "https://upload.pypi.org/legacy/"
-  PYTHON_VERSION: "3.10"
+  PYTHON_VERSION: ${{ vars.PYTHON_VERSION || "3.10" }}
   WORKFLOW_BRANCH: "main"
 
 permissions:

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -19,7 +19,7 @@ on:
 
 env:
   PYPI_REGISTRY: "https://upload.pypi.org/legacy/"
-  PYTHON_VERSION: ${{ vars.PYTHON_VERSION || "3.10" }}
+  PYTHON_VERSION: ${{ vars.PYTHON_VERSION || '3.10' }}
   WORKFLOW_BRANCH: "main"
 
 permissions:

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -2,6 +2,11 @@ name: publish-python
 
 on:
   workflow_call:
+    inputs:
+      python_version:
+        type: string
+        required: false
+
     secrets:
       PYPI_USERNAME:
         required: true
@@ -51,7 +56,7 @@ jobs:
         with:
           enable_node: false
           enable_python: true
-          python_version: ${{ secrets.PYTHON_VERSION || env.PYTHON_VERSION }}
+          python_version: ${{ inputs.python_version || secrets.PYTHON_VERSION || env.PYTHON_VERSION }}
           github_ro_token: ${{ github.event.repository.private == true && secrets.DATAVISYN_BOT_REPO_TOKEN || github.token }}
       - uses: ./tmp/github-workflows/.github/actions/publish-python
         with:


### PR DESCRIPTION
One can now adjust the python and node version either via repository variables (to apply to all workflows), or via inputs in the `with:` clause when calling workflows. 