### PR TITLE
feat: add OVERRIDE_RUNS_ON variables to control runners per repository

### DIFF
--- a/.github/workflows/build-docker-artifacts-push.yml
+++ b/.github/workflows/build-docker-artifacts-push.yml
@@ -42,7 +42,7 @@ permissions:
 jobs:
   post-build:
     name: Push ${{ inputs.repository }}:${{ inputs.image_tag }} docker artifacts to ${{ inputs.customer }}
-    runs-on: ${{ inputs.runs_on || 'ubuntu-22.04' }}
+    runs-on: ${{ vars.RUNS_ON_OVERRIDE || inputs.runs_on || 'ubuntu-22.04' }}
 
     steps:
       - name: Checkout repository (must be run in infrastructure-k8s)

--- a/.github/workflows/build-docker-artifacts-trigger-push.yml
+++ b/.github/workflows/build-docker-artifacts-trigger-push.yml
@@ -37,7 +37,7 @@ permissions:
 jobs:
   get-customers:
     name: Get customers to push to (${{ inputs.push_to || 'all' }})
-    runs-on: ${{ inputs.runs_on || 'ubuntu-22.04' }}
+    runs-on: ${{ vars.RUNS_ON_OVERRIDE || inputs.runs_on || 'ubuntu-22.04' }}
     outputs:
       result: ${{ steps.get-customers.outputs.result }}
 
@@ -96,7 +96,7 @@ jobs:
       fail-fast: true
       matrix:
         customer: ${{ fromJson(needs.get-customers.outputs.result) }}
-    runs-on: ${{ inputs.runs_on }}
+    runs-on: ${{ vars.RUNS_ON_OVERRIDE || inputs.runs_on || 'ubuntu-22.04' }}
     steps:
       - name: Trigger push docker artifacts to ${{ matrix.customer.customer }}
         if: ${{ matrix.customer.customer_json.skip != true }}

--- a/.github/workflows/build-docker-artifacts.yml
+++ b/.github/workflows/build-docker-artifacts.yml
@@ -153,7 +153,7 @@ jobs:
       fail-fast: ${{ inputs.fail_fast }}
       matrix:
         component: ${{ fromJson(needs.get-flavors.outputs.result).components }}
-    runs-on: ${{ vars.OVERRIDE_BUILD_DOCKER_ARTIFACTS_RUNS_ON || inputs.runs_on || 'ubuntu-22.04' }}
+    runs-on: ${{ vars.BUILD_DOCKER_ARTIFACTS_RUNS_ON_OVERRIDE || vars.RUNS_ON_OVERRIDE || inputs.runs_on || 'ubuntu-22.04' }}
     steps:
       - name: View flavor and component
         shell: bash

--- a/.github/workflows/build-docker-artifacts.yml
+++ b/.github/workflows/build-docker-artifacts.yml
@@ -153,7 +153,7 @@ jobs:
       fail-fast: ${{ inputs.fail_fast }}
       matrix:
         component: ${{ fromJson(needs.get-flavors.outputs.result).components }}
-    runs-on: ${{ inputs.runs_on || 'ubuntu-22.04' }}
+    runs-on: ${{ vars.OVERRIDE_BUILD_DOCKER_ARTIFACTS_RUNS_ON || inputs.runs_on || 'ubuntu-22.04' }}
     steps:
       - name: View flavor and component
         shell: bash

--- a/.github/workflows/build-node-python.yml
+++ b/.github/workflows/build-node-python.yml
@@ -139,7 +139,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    runs-on: ${{ inputs.runs_on || 'ubuntu-22.04' }}
+    runs-on: ${{ vars.BUILD_RUNS_ON_OVERRIDE || vars.RUNS_ON_OVERRIDE || inputs.runs_on || 'ubuntu-22.04' }}
     steps:
       - name: Checkout source repository
         uses: actions/checkout@v5
@@ -182,7 +182,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    runs-on: ${{ inputs.runs_on || 'ubuntu-22.04' }}
+    runs-on: ${{ vars.BUILD_RUNS_ON_OVERRIDE || vars.RUNS_ON_OVERRIDE || inputs.runs_on || 'ubuntu-22.04' }}
     steps:
       - name: Checkout source repository
         uses: actions/checkout@v5
@@ -221,7 +221,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    runs-on: ${{ inputs.cypress_runs_on || inputs.runs_on || 'ubuntu-22.04-large' }}
+    runs-on: ${{ vars.CYPRESS_RUNS_ON_OVERRIDE || vars.RUNS_ON_OVERRIDE || inputs.cypress_runs_on || inputs.runs_on || 'ubuntu-22.04-large' }}
 
     services:
       postgres:
@@ -362,7 +362,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    runs-on: ${{ inputs.playwright_runs_on || inputs.runs_on || 'ubuntu-22.04-large' }}
+    runs-on: ${{ vars.PLAYWRIGHT_RUNS_ON_OVERRIDE || vars.RUNS_ON_OVERRIDE || inputs.playwright_runs_on || inputs.runs_on || 'ubuntu-22.04-large' }}
 
     services:
       postgres:

--- a/.github/workflows/build-node.yml
+++ b/.github/workflows/build-node.yml
@@ -54,7 +54,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    runs-on: ${{ inputs.runs_on || 'ubuntu-22.04' }}
+    runs-on: ${{ vars.BUILD_RUNS_ON_OVERRIDE || vars.RUNS_ON_OVERRIDE || inputs.runs_on || 'ubuntu-22.04' }}
     steps:
       - name: Checkout source repository
         uses: actions/checkout@v5

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -43,7 +43,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    runs-on: ${{ inputs.runs_on || 'ubuntu-22.04' }}
+    runs-on: ${{ vars.BUILD_RUNS_ON_OVERRIDE || vars.RUNS_ON_OVERRIDE || inputs.runs_on || 'ubuntu-22.04' }}
     steps:
       - name: Checkout source repository
         uses: actions/checkout@v5

--- a/.github/workflows/build-single-product-part.yml
+++ b/.github/workflows/build-single-product-part.yml
@@ -66,7 +66,7 @@ permissions:
 jobs:
   build-components:
     timeout-minutes: ${{ fromJSON(inputs.timeout) }}
-    runs-on: ${{ inputs.runs_on || 'ubuntu-22.04' }}
+    runs-on: ${{ vars.RUNS_ON_OVERRIDE || inputs.runs_on || 'ubuntu-22.04' }}
     steps:
       - name: Remove unnecessary files
         run: |


### PR DESCRIPTION
Adds the following variables which can be set in https://github.com/datavisyn/<repo>/settings/variables/actions to globally change the runners of all jobs, i.e. in case the self-hosted runners are not working:

- RUNS_ON_OVERRIDE
- BUILD_DOCKER_ARTIFACTS_RUNS_ON_OVERRIDE
- BUILD_RUNS_ON_OVERRIDE
- PLAYWRIGHT_RUNS_ON_OVERRIDE
- CYPRESS_RUNS_ON_OVERRIDE
